### PR TITLE
fix: correct etl-morphology column mapping for strongs and word_position

### DIFF
--- a/scripts/etl-morphology.ts
+++ b/scripts/etl-morphology.ts
@@ -151,26 +151,28 @@ function log(msg: string): void {
 // ---------------------------------------------------------------------------
 // Reference parser
 //
-// STEPBible references are formatted as: BookAbbr.Chapter.Verse
-// e.g. "Gen.1.1" or "Mat.1.1"
+// STEPBible references are formatted as: BookAbbr.Chapter.Verse#WordPos=Type
+// e.g. "Gen.1.1#01=L" or "Mat.1.1#01=NKO"
 //
-// Some data sources also include a word index as a 4th component: "Mat.1.1.01"
-// but in TAHOT/TAGNT the word position appears in a separate column (Pos).
+// The word position is embedded in col 0 after the '#' sign, before the '='.
+// e.g. "Mat.1.1#01=NKO" → word_position = "01"
+//      "Gen.1.1#01=L"   → word_position = "01"
 // ---------------------------------------------------------------------------
 
 interface ParsedRef {
   book_id: number;
   chapter: number;
   verse: number;
+  word_position: string | null;
 }
 
 function parseRef(ref: string): ParsedRef | null {
-  // Handle references with trailing word index component — drop it
   const parts = ref.split('.');
   if (parts.length < 3) return null;
 
   const bookAbbr = parts[0];
   const chapter = parseInt(parts[1], 10);
+  // The third dot-part may contain "#01=NKO" — parseInt stops at '#'
   const verse = parseInt(parts[2], 10);
 
   if (isNaN(chapter) || isNaN(verse)) return null;
@@ -178,7 +180,11 @@ function parseRef(ref: string): ParsedRef | null {
   const book_id = STEPBIBLE_BOOK_MAP[bookAbbr];
   if (book_id === undefined) return null;
 
-  return { book_id, chapter, verse };
+  // Extract word position: everything between '#' and '=' (or end of string)
+  const hashMatch = /#([^=]+)/.exec(ref);
+  const word_position = hashMatch ? hashMatch[1] : null;
+
+  return { book_id, chapter, verse, word_position };
 }
 
 // ---------------------------------------------------------------------------
@@ -189,14 +195,43 @@ function parseRef(ref: string): ParsedRef | null {
 //   Extended: H1254a  (disambiguated sub-entry — strip trailing letters for primary)
 //   Compound: H1254a=H1254&H0001  (multi-root — primary is the part before '=')
 //
+// TAGNT format (col 3, dStrongs = Grammar):
+//   "G0976=N-NSF"   — Strong's before '=', morphology after '='
+//   "G2424G=N-GSM-P" — with trailing letter disambiguator
+//
+// TAHOT format (col 4, dStrongs):
+//   "{H7225G}"           — curly-brace dStrong notation
+//   "H9003/{H7225G}"     — compound: prefix Strong's/root Strong's
+//   "H9002/H9009/{H0776G}" — multiple prefixes then root
+//
 // Rules (decision #7 + #8):
 //   strongs_number = primary Strong's number (H/G prefix + 4-digit zero-padded)
 //   raw_strongs    = full original string as it appears in the file
+//
+// For TAHOT curly-brace notation, the primary Strong's is:
+//   - The Strong's number outside curly braces (leftmost prefix) if present
+//   - Otherwise the first Strong's number inside curly braces
+//   The root word meaning is typically inside {}, but the prefix preposition/conjunction
+//   is the grammatically primary element for the token.
 // ---------------------------------------------------------------------------
 
 interface ParsedStrongs {
   strongs_number: string | null;
   raw_strongs: string | null;
+}
+
+/**
+ * Normalise a raw H/G token to 4-digit zero-padded form.
+ * e.g. "H1254a" → "H1254", "G3056B" → "G3056", "H1" → "H0001"
+ * Returns null if token does not match expected format.
+ */
+function normaliseStrongsToken(token: string): string | null {
+  // Strip trailing disambiguating letters (e.g. H1254a → H1254, G2424G → G2424)
+  const match = /^([HG])(\d+)[A-Za-z]*$/.exec(token.trim());
+  if (!match) return null;
+  const prefix = match[1];
+  const digits = match[2].padStart(4, '0');
+  return `${prefix}${digits}`;
 }
 
 function parseStrongs(raw: string): ParsedStrongs {
@@ -208,31 +243,51 @@ function parseStrongs(raw: string): ParsedStrongs {
   // raw_strongs preserves the full notation exactly
   const raw_strongs = trimmed;
 
-  // Extract primary number — the part before any '=' (for compound notation)
-  // then strip trailing disambiguating letters to get the base number.
-  // e.g. "H1254a=H1254&H0001" → primary candidate = "H1254a" → "H1254"
-  // e.g. "G3056B" → "G3056"
-  // e.g. "H0001" → "H0001"
-  const primaryCandidate = trimmed.split('=')[0].trim();
+  // --- TAHOT curly-brace notation ---
+  // Formats: "{H7225G}", "H9003/{H7225G}", "H9002/H9009/{H0776G}", etc.
+  // The primary Strong's number is:
+  //   1. The first token outside curly braces (a prefix like H9003), if one exists
+  //   2. Otherwise the first token inside curly braces
+  if (trimmed.includes('{')) {
+    // Extract first non-curly-brace token (outside {})
+    // Tokens are separated by '/' — find the first part that isn't wrapped in {}
+    // and doesn't contain a '='
+    const segments = trimmed.split('/');
+    for (const seg of segments) {
+      const s = seg.trim();
+      if (!s.startsWith('{') && !s.includes('=')) {
+        // Could be a plain Strong's token like H9003
+        const normalised = normaliseStrongsToken(s);
+        if (normalised) {
+          return { strongs_number: normalised, raw_strongs };
+        }
+      }
+    }
 
-  // Match: optional letter prefix, then H or G, then digits, then optional trailing letters
-  const match = /^([HG]\d+)[A-Za-z]*$/.exec(primaryCandidate);
-  if (!match) {
+    // All tokens are in curly braces — extract first one inside {}
+    const curlyMatch = /\{([^}]+)\}/.exec(trimmed);
+    if (curlyMatch) {
+      // Content inside {} may have trailing suffixes like H7225G — strip them
+      const inner = curlyMatch[1].trim();
+      const normalised = normaliseStrongsToken(inner);
+      if (normalised) {
+        return { strongs_number: normalised, raw_strongs };
+      }
+    }
+
+    // Could not parse — return raw only
+    return { strongs_number: null, raw_strongs };
+  }
+
+  // --- TAGNT / standard notation ---
+  // "G0976=N-NSF" → primary candidate = "G0976" (before '=')
+  // "H1254a=H1254&H0001" → primary candidate = "H1254a" → "H1254"
+  const primaryCandidate = trimmed.split('=')[0].trim();
+  const strongs_number = normaliseStrongsToken(primaryCandidate);
+  if (!strongs_number) {
     // Non-standard format — keep raw, no primary
     return { strongs_number: null, raw_strongs };
   }
-
-  const baseWithPrefix = match[1]; // e.g. "H1254" or "G3056"
-
-  // Normalise to H/G + 4-digit zero-padded (H1254 → H1254, H1 → H0001)
-  const prefixMatch = /^([HG])(\d+)$/.exec(baseWithPrefix);
-  if (!prefixMatch) {
-    return { strongs_number: null, raw_strongs };
-  }
-
-  const prefix = prefixMatch[1];
-  const digits = prefixMatch[2].padStart(4, '0');
-  const strongs_number = `${prefix}${digits}`;
 
   return { strongs_number, raw_strongs };
 }
@@ -242,31 +297,32 @@ function parseStrongs(raw: string): ParsedStrongs {
 //
 // File format (tab-separated, UTF-8):
 //   Lines starting with '#' are comments/documentation — skip.
-//   The first non-comment line is the column header (starts with 'Ref').
+//   A column header line appears before each book section (repeating headers).
 //   Data lines follow the header format.
 //
-// TAHOT column layout (Hebrew OT):
-//   Col 0: Ref          — "Gen.1.1"
-//   Col 1: Pos          — word position within verse, may be "1", "1a", "1b"
-//   Col 2: Str/dStrong  — Strong's number(s), may be compound: "H1254a=H1254&H0001"
-//   Col 3: Morph        — morphology code, e.g. "HVqp3ms"
-//   Col 4: Heb          — Hebrew word (original script)
-//   Col 5: Translit     — transliteration
-//   Col 6: Gloss        — word-level English gloss / translation
-//   (additional columns may exist — ignored)
+// TAGNT column layout (Greek NT) — header starts with "Word & Type":
+//   Col 0: Word & Type       — "Mat.1.1#01=NKO" (ref + word index + edition)
+//   Col 1: Greek             — "Βίβλος (Biblos)" Greek word + transliteration
+//   Col 2: English translation — "[The] book" English gloss (NOT Strong's!)
+//   Col 3: dStrongs = Grammar — "G0976=N-NSF" Strong's number = morphology code
+//   Col 4: Dictionary form = Gloss — "βίβλος=book" lemma=gloss
+//   Col 5: editions          — "NA28+NA27+..." manuscript editions
+//   (additional columns ignored)
 //
-// TAGNT column layout (Greek NT):
-//   Col 0: Ref          — "Mat.1.1"
-//   Col 1: Pos          — word position within verse
-//   Col 2: dStrong      — Strong's number(s)
-//   Col 3: Morph        — Robinson morphology code, e.g. "N-NSF"
-//   Col 4: Grk          — Greek word (original script)
-//   Col 5: Translit     — transliteration
-//   Col 6: Gloss        — word-level English gloss
-//   Col 7: Editions     — manuscript edition attestation codes (TAGNT-specific)
-//   (additional columns may exist — ignored)
+// TAHOT column layout (Hebrew OT) — header starts with "Eng (Heb) Ref & Type":
+//   Col 0: Eng (Heb) Ref & Type — "Gen.1.1#01=L" (ref + word index + type)
+//   Col 1: Hebrew              — "בְּ/רֵאשִׁ֖ית" Hebrew word
+//   Col 2: Transliteration     — "be./re.Shit" transliteration (NOT Strong's!)
+//   Col 3: Translation         — "in/ beginning" English translation
+//   Col 4: dStrongs            — "H9003/{H7225G}" Strong's number(s) — curly-brace notation
+//   Col 5: Grammar             — "HR/Ncfsa" morphology code
+//   Col 6+: variants, root info, etc. (ignored)
 //
-// Both formats share the same column positions for the fields we care about.
+// Key differences:
+//   TAGNT col 3 encodes both Strong's AND morphology as "G0976=N-NSF".
+//     parseStrongs extracts "G0976" (before '='), morph stored as full col 3 value.
+//   TAHOT col 4 uses curly-brace dStrong notation: "{H7225G}" or "H9003/{H7225G}".
+//     parseStrongs handles this notation. Morphology is col 5.
 // ---------------------------------------------------------------------------
 
 interface ParseFileResult {
@@ -279,18 +335,29 @@ function parseFile(filePath: string, translationId: number): ParseFileResult {
   const content = fs.readFileSync(filePath, 'utf-8');
   const lines = content.split('\n');
 
+  // Detect file type from path for correct column defaults.
+  // These are hardcoded from verified file inspection — do not rely on header
+  // parsing alone since the header detection was previously broken.
+  const isTAGNT = path.basename(filePath).startsWith('TAGNT');
+
   const rows: MorphologyRow[] = [];
   let skipped = 0;
   let compoundCount = 0;
-  let headerSeen = false;
 
-  // Column indices discovered from header row
-  let colRef = 0;
-  let colPos = 1;
-  let colStrongs = 2;
-  let colMorph = 3;
-  let colLemma = 4;
-  let colGloss = 6;
+  // Column indices — set correct defaults per file type.
+  //
+  // TAGNT (Greek NT): header "Word & Type"
+  //   0=Ref+index, 1=Greek word, 2=English gloss, 3=dStrongs=Grammar, 4=lemma=gloss
+  //
+  // TAHOT (Hebrew OT): header "Eng (Heb) Ref & Type"
+  //   0=Ref+index, 1=Hebrew word, 2=transliteration, 3=Translation, 4=dStrongs, 5=Grammar
+  //
+  // Note: word_position is NOT a column — it is parsed from col 0 (the ref field)
+  // after the '#' sign. e.g. "Mat.1.1#01=NKO" → word_position = "01"
+  const colRef = 0;
+  const colStrongs = isTAGNT ? 3 : 4;   // dStrongs=Grammar (TAGNT) or dStrongs (TAHOT)
+  const colMorph = isTAGNT ? 3 : 5;     // same as colStrongs for TAGNT (combined field)
+  const colLemma = isTAGNT ? 4 : 1;     // Dictionary form=Gloss (TAGNT) or Hebrew word (TAHOT)
 
   for (const rawLine of lines) {
     const line = rawLine.trimEnd();
@@ -300,18 +367,11 @@ function parseFile(filePath: string, translationId: number): ParseFileResult {
 
     const cols = line.split('\t');
 
-    // The header row begins with 'Ref' — use it to discover column positions
-    if (!headerSeen && cols[0].trim() === 'Ref') {
-      headerSeen = true;
-      for (let i = 0; i < cols.length; i++) {
-        const h = cols[i].trim().toLowerCase();
-        if (h === 'ref') colRef = i;
-        else if (h === 'pos' || h === 'word') colPos = i;
-        else if (h === 'strongs' || h === 'dstrongs' || h === 'str' || h === 'dstrong') colStrongs = i;
-        else if (h === 'morph') colMorph = i;
-        else if (h === 'heb' || h === 'grk' || h === 'hebrew' || h === 'greek') colLemma = i;
-        else if (h === 'gloss') colGloss = i;
-      }
+    // Detect and skip header rows.
+    // TAGNT header: cols[0] starts with "Word & Type"
+    // TAHOT header: cols[0] starts with "Eng (Heb) Ref & Type"
+    const firstCol = cols[0].trim();
+    if (firstCol === 'Word & Type' || firstCol === 'Eng (Heb) Ref & Type') {
       continue;
     }
 
@@ -322,13 +382,11 @@ function parseFile(filePath: string, translationId: number): ParseFileResult {
     }
 
     const refRaw = cols[colRef]?.trim() ?? '';
-    const posRaw = cols[colPos]?.trim() ?? '';
     const strongsRaw = cols[colStrongs]?.trim() ?? '';
     const morphRaw = cols[colMorph]?.trim() ?? '';
     const lemmaRaw = cols[colLemma]?.trim() ?? '';
-    const glossRaw = cols.length > colGloss ? (cols[colGloss]?.trim() ?? '') : '';
 
-    // Parse reference
+    // Parse reference — word_position is extracted from the '#' fragment in col 0
     const ref = parseRef(refRaw);
     if (!ref) {
       skipped++;
@@ -336,13 +394,13 @@ function parseFile(filePath: string, translationId: number): ParseFileResult {
     }
 
     // Skip lines with no word position (malformed or section markers)
-    if (!posRaw || posRaw === '-') {
+    if (!ref.word_position) {
       skipped++;
       continue;
     }
 
-    // word_position is stored as TEXT — handles "1", "1a", "1b" etc.
-    const word_position = posRaw;
+    // word_position is stored as TEXT — handles "01", "1a", "1b" etc.
+    const word_position = ref.word_position;
 
     // Parse Strong's
     const { strongs_number, raw_strongs } = parseStrongs(strongsRaw);
@@ -355,8 +413,8 @@ function parseFile(filePath: string, translationId: number): ParseFileResult {
     // parsing: prefer morphology code; fall back to null if empty/dash
     const parsing = morphRaw && morphRaw !== '-' ? morphRaw : null;
 
-    // lemma: prefer original-script word; fall back to gloss if empty
-    const lemma = lemmaRaw && lemmaRaw !== '-' ? lemmaRaw : (glossRaw && glossRaw !== '-' ? glossRaw : null);
+    // lemma: use column value; null if empty or dash
+    const lemma = lemmaRaw && lemmaRaw !== '-' ? lemmaRaw : null;
 
     rows.push({
       book_id: ref.book_id,


### PR DESCRIPTION
## Why

The prior ETL fix (PR #14) corrected sub-entry handling and Ketiv/Qere deduplication, but the column mapping in `etl-morphology.ts` was still wrong. The header detection never fired, causing `colStrongs` and `colPos` to point at wrong columns — producing NULL `strongs_number` for all 428K morphology rows and storing Greek/Hebrew word text as `word_position` instead of the actual numeric position. This made the `word_study` tool return empty definitions and broken positional lookups.

## What This Does

Hardcodes correct column indices per file type (verified against actual TAGNT/TAHOT data files), extracts `word_position` from the ref field's `#XX` fragment, and adds curly-brace notation handling for TAHOT Strong's numbers. After ETL re-run, all 447K morphology rows have correct `strongs_number` and `word_position` values — verified via D1 query.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)