### PR TITLE
feat: add MCP tool annotation hints

### DIFF
--- a/src/tools/compare-translations.ts
+++ b/src/tools/compare-translations.ts
@@ -122,6 +122,12 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
   return response;
 };
 
+compareTranslations.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 compareTranslations.description =
   'Compare the same Bible passage side-by-side across all 5 translations (KJV, WEB, ASV, YLT, Darby). ' +
   'Accepts a book name or alias, chapter, and verse range. Returns every verse with its text and a ' +

--- a/src/tools/concordance.ts
+++ b/src/tools/concordance.ts
@@ -176,6 +176,12 @@ const concordance: ToolHandler = async (args, _ask?) => {
   return response;
 };
 
+concordance.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 concordance.description =
   'Survey every occurrence of a word across the entire Bible, grouped by book in canonical order. ' +
   'Searches single words only; use find_text for phrases. ' +

--- a/src/tools/cross-references.ts
+++ b/src/tools/cross-references.ts
@@ -151,6 +151,12 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
   return response;
 };
 
+crossReferences.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 crossReferences.description =
   'Find cross-references for a specific Bible verse — related passages that share themes, ' +
   'language, or doctrinal connections. Draws from 606K curated references. ' +

--- a/src/tools/find-text.ts
+++ b/src/tools/find-text.ts
@@ -152,6 +152,12 @@ const findText: ToolHandler = async (args, _ask?) => {
   return response;
 };
 
+findText.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 findText.description =
   'Find Bible verses containing an exact, case-insensitive word or phrase using full-text search. ' +
   'Use this when you know the specific wording to search for (e.g. "consider the lilies", "fear not"). ' +

--- a/src/tools/search-bible.ts
+++ b/src/tools/search-bible.ts
@@ -409,6 +409,12 @@ const searchBible: ToolHandler = async (args, _ask?) => {
   return output;
 };
 
+searchBible.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 searchBible.description =
   'Search the Bible by meaning using AI semantic similarity — finds conceptually related verses even when they do not contain the query words. Use this for open-ended questions ("what does the Bible say about anxiety?") or thematic queries. Prefer topical_search for classic theological topics (faith, grace, forgiveness) where Nave\'s curated index adds value. Prefer find_text when you need an exact word or phrase match. Optionally filter by translation (KJV, WEB, ASV, YLT, Darby), book, or testament (OT/NT). Without a translation filter, each verse location returns all matching translations (up to 5x results). Returns ranked results with full citation and verse text.';
 

--- a/src/tools/topical-search.ts
+++ b/src/tools/topical-search.ts
@@ -291,6 +291,12 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
   return response;
 };
 
+topicalSearch.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 topicalSearch.description =
   'Find Bible verses on a theological topic using Nave\'s curated Topical Bible index combined with AI semantic search. ' +
   'Nave\'s index covers 5,319 theological topics. ' +

--- a/src/tools/word-study.ts
+++ b/src/tools/word-study.ts
@@ -570,6 +570,12 @@ function buildOtherOccurrencesInline(
 
 // ─── Metadata ─────────────────────────────────────────────────────────────────
 
+wordStudy.annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+
 wordStudy.description =
   'Perform an original language word study for a specific word in a Bible verse. ' +
   'You MUST provide an exact verse reference (book, chapter, verse). Use search_bible or find_text first if you need to locate the verse. ' +


### PR DESCRIPTION
## Why

ChatGPT app store submission requires correct tool annotation hints, and MCP clients use them to determine permission prompts and safety UI. Without explicit hints, clients default to the most restrictive combination (read-write, destructive, open-world).

## What This Does

Adds readOnlyHint: true, destructiveHint: false, and openWorldHint: true annotations to all 7 tools. A local patch to @mctx-ai/mcp-server enables annotation support in tools/list responses (native framework support being added separately).

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)