### PR TITLE
chore: bump mcp-server to 1.1.0 for native annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mctx-ai/mcp-server": "^1.0.0"
+        "@mctx-ai/mcp-server": "^1.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
-        "@mctx-ai/mcp-dev": "^1.0.0",
+        "@mctx-ai/mcp-dev": "^1.0.1",
         "@types/node": "^25.3.5",
         "esbuild": "^0.27.3",
         "eslint": "^9.17.0",
@@ -672,9 +672,9 @@
       "license": "MIT"
     },
     "node_modules/@mctx-ai/mcp-dev": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp-dev/-/mcp-dev-1.0.0.tgz",
-      "integrity": "sha512-8ECOOzmqKk5cliebn1OZXEZFxf/3VNEM5qITS89nt4WXCStxf2FohIKC/mjvMb3LLIrPMVYbhZQlIbL3+KEbxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp-dev/-/mcp-dev-1.0.1.tgz",
+      "integrity": "sha512-rKw93kt0Fj0gpKvmFMPD/mUgURjy3jLAIzTGt/Hk5chXhOwu5uWoPcnuqz1ena6DYxh+Xerz96Yl5O+Z2f3hxA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -684,13 +684,13 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@mctx-ai/mcp-server": "^1.0.0"
+        "@mctx-ai/mcp-server": "1.1.0"
       }
     },
     "node_modules/@mctx-ai/mcp-server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp-server/-/mcp-server-1.0.0.tgz",
-      "integrity": "sha512-iGIeFIMz6dCJmKshHEcTdODxm3KRqiu5j2gr7O2afEaXFsxI5MqzhMC/kuROWOn9cBA+ONtipeZO8e2Mzi+8CA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp-server/-/mcp-server-1.1.0.tgz",
+      "integrity": "sha512-x2tpLs5ILUgbf+BvDj1JDSFutcs3ubPFQOiHTGjgVVN4pzAIdyx5KCKO8msfOV8LcgyF63VS7VgBdc5+HQg6yw==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.scripts.json"
   },
   "dependencies": {
-    "@mctx-ai/mcp-server": "^1.0.0"
+    "@mctx-ai/mcp-server": "^1.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@mctx-ai/mcp-dev": "^1.0.0",
+    "@mctx-ai/mcp-dev": "^1.0.1",
     "@types/node": "^25.3.5",
     "esbuild": "^0.27.3",
     "eslint": "^9.17.0",


### PR DESCRIPTION
## Why

The tool annotation hints added in PR #19 relied on a local node_modules patch because @mctx-ai/mcp-server v1.0.0 didn't support annotations natively. That patch is lost on fresh npm ci.

## What This Does

Bumps @mctx-ai/mcp-server to 1.1.0 which ships native annotations support, eliminating the fragile node_modules patch. The tool handler annotations already set in PR #19 now work durably.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)