### PR TITLE
feat: add idempotentHint annotation to all tools

### DIFF
--- a/src/tools/compare-translations.ts
+++ b/src/tools/compare-translations.ts
@@ -125,6 +125,7 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
 compareTranslations.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/concordance.ts
+++ b/src/tools/concordance.ts
@@ -179,6 +179,7 @@ const concordance: ToolHandler = async (args, _ask?) => {
 concordance.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/cross-references.ts
+++ b/src/tools/cross-references.ts
@@ -154,6 +154,7 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
 crossReferences.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/find-text.ts
+++ b/src/tools/find-text.ts
@@ -155,6 +155,7 @@ const findText: ToolHandler = async (args, _ask?) => {
 findText.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/search-bible.ts
+++ b/src/tools/search-bible.ts
@@ -412,6 +412,7 @@ const searchBible: ToolHandler = async (args, _ask?) => {
 searchBible.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/topical-search.ts
+++ b/src/tools/topical-search.ts
@@ -294,6 +294,7 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
 topicalSearch.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 

--- a/src/tools/word-study.ts
+++ b/src/tools/word-study.ts
@@ -573,6 +573,7 @@ function buildOtherOccurrencesInline(
 wordStudy.annotations = {
   readOnlyHint: true,
   destructiveHint: false,
+  idempotentHint: true,
   openWorldHint: true,
 };
 


### PR DESCRIPTION
## Why

The tool annotations added in PR #19 and refined in PR #20 were missing idempotentHint. All 7 tools are pure read operations that produce identical results on retry — clients should know this for safe auto-retry behavior.

## What This Does

Adds idempotentHint: true to all 7 tool annotation objects, completing the full set of MCP tool behavioral hints (readOnlyHint, destructiveHint, openWorldHint, idempotentHint).

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)