### PR TITLE
chore: rebrand to MCP server terminology + v2 framework migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A **Bible study MCP server** built with `@mctx-ai/app` framework, deployed on the mctx.ai platform at `bible-study.mctx.ai`.
+A **Bible study MCP server** built with `@mctx-ai/mcp` framework (v2), deployed on the mctx.ai platform at `bible-study.mctx.ai`.
 
 **Purpose:** Deep Bible study for MCP-compatible AI clients. 155,510 verses across 5 public domain translations (KJV, WEB, ASV, YLT, Darby). Semantic search via 155K+ vector embeddings. 606,140 cross-references. 17,543 Strong's concordance entries with Hebrew and Greek lexicon definitions. 447,734 morphology records. 5,319 Nave's Topical Bible categories. Full-text search via FTS5.
 
@@ -61,11 +61,21 @@ Violating this boundary causes Cloudflare Workers deployment failure (error 1002
 2. Attach metadata (`.description`, `.input`, `.mimeType`)
 3. Register with server via `server.tool()`, `server.resource()`, or `server.prompt()`
 
-**Handler signatures:**
-- **ToolHandler:** `(args, ask?) => string | object | Promise<string | object>`
-- **GeneratorToolHandler:** `function* (args) { yield progress; return result; }`
-- **ResourceHandler:** `(params) => string`
-- **PromptHandler:** `(args) => string | conversation(...)`
+**Handler signatures (v2):**
+
+All handler types use `(mctx, req, res)`:
+- `mctx` — `ModelContext` with optional `userId`
+- `req` — validated input fields accessed directly (`req.query`, `req.book`, etc.)
+- `res` — output port: `res.send(value)`, `res.progress(current, total?)`, `res.ask(prompt)`
+
+Examples:
+- **ToolHandler:** `(mctx, req, res) => { res.send(result); }`
+- **ResourceHandler:** `(mctx, req, res) => { res.send(JSON.stringify(data)); }`
+- **PromptHandler:** `(mctx, req, res) => { res.send(conversation(...)); }`
+
+Handlers no longer return values. Call `res.send()` to emit the result.
+Progress uses `res.progress(current, total?)` instead of generator functions.
+Sampling uses `res.ask(prompt)` instead of the `ask` parameter.
 
 **Schema system:** The `T` namespace provides type-safe schema builders (`.string()`, `.number()`, `.boolean()`, etc.) with validation constraints.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ If any of these are not being synced, the release workflow needs to be updated.
 
 Any change that affects external behavior, user-visible output, or tool capabilities **must** trigger a review of:
 
-1. **`README.md`** — This is the public product page on mctx.ai, not developer docs. Review against mctx's recommended 7-section structure (Opening Hook, Differentiation, What You Get, How It Works, Using This App, Example Phrases, Real-World Workflows). See [mctx docs on writing a good README](https://docs.mctx.ai/building-mcp-servers/server-requirements#writing-a-good-readme).
+1. **`README.md`** — This is the public product page on mctx.ai, not developer docs. Review against mctx's recommended 7-section structure (Opening Hook, Differentiation, What You Get, How It Works, Using This Server, Example Phrases, Real-World Workflows). See [mctx docs on writing a good README](https://docs.mctx.ai/building-mcp-servers/server-requirements#writing-a-good-readme).
 
 2. **`package.json` `description` field** — First 100 characters are the hook shown in registry listings. Must reflect current capabilities. See [mctx docs on description](https://docs.mctx.ai/configuration/mctx-json#description).
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 A complete scholarly Bible study toolkit — semantic search, original-language word studies, translation comparison, cross-reference traversal, and topical research — available as AI-native tools for the first time.
 
-Without this App, deep Bible study means juggling multiple browser tabs: a concordance site here, a lexicon there, a translation comparison tool somewhere else. You lose the thread of your research every time you switch. This App brings all of that into your AI assistant, where each result informs the next question and the entire study session stays in one conversation.
+Without this server, deep Bible study means juggling multiple browser tabs: a concordance site here, a lexicon there, a translation comparison tool somewhere else. You lose the thread of your research every time you switch. This server brings all of that into your AI assistant, where each result informs the next question and the entire study session stays in one conversation.
 
-Unlike asking your AI from general knowledge, this App gives your assistant access to structured scholarly data that no training set contains: 17,543 Strong's entries with full BDB and Thayer lexicon definitions, morphological parsing for 447,734 individual words, the complete OpenBible cross-reference dataset, and Nave's 5,319 topical categories.
+---
+
+## Why This Is Different
+
+Most AI assistants answer Bible questions from training data alone — approximations drawn from whatever made it into the model. This server gives your assistant access to structured scholarly data that no training set contains: 17,543 Strong's entries with full BDB and Thayer lexicon definitions, morphological parsing for 447,734 individual words, the complete OpenBible cross-reference dataset, and Nave's 5,319 topical categories. When you ask about the Greek word for grace or the cross-references for John 3:16, the answer comes from the primary sources — not a paraphrase of them.
 
 ---
 
@@ -28,7 +32,7 @@ Unlike asking your AI from general knowledge, this App gives your assistant acce
 
 ## How It Works
 
-When you ask a Bible study question, the App queries a purpose-built database and returns structured data your AI assistant can reason about directly. The AI gets facts and definitions, not HTML pages it has to summarize.
+When you ask a Bible study question, the server queries a purpose-built database and returns structured data your AI assistant can reason about directly. The AI gets facts and definitions, not HTML pages it has to summarize.
 
 Seven capabilities work together: meaning-based verse discovery, curated thematic research with major witnesses, keyword search, word frequency across books, side-by-side translation rendering, passage-to-passage connections, and original-language deep dives.
 
@@ -36,9 +40,9 @@ Because each query returns structured data, the tools chain naturally in a singl
 
 ---
 
-## Using This App
+## Using This Server
 
-Once subscribed, just talk to your AI assistant as you normally would. Ask your Bible study questions naturally — no special syntax. The assistant handles the research behind the scenes.
+Once subscribed, talk to your AI assistant as you normally would — no special syntax or commands required. Ask Bible study questions the same way you would ask a knowledgeable colleague: "What does the Greek say here?", "What other passages connect to this one?", or "What does the Bible teach about covenant?" The assistant routes each question to the right tools automatically and weaves the results into its response, so your research thread stays intact from the first question to the last.
 
 ---
 
@@ -75,7 +79,17 @@ You are preparing to preach or teach and need cross-references, lexical support,
 
 ---
 
-## Example Responses
+## Real-World Workflows
+
+**The pastor drafting Sunday's sermon on Wednesday afternoon.** She's preaching on Psalm 23 and wants to know how the Hebrew behind "restore my soul" has been translated across history. She asks her AI assistant to pull the Strong's entry for the root verb, compare how KJV, ASV, and YLT each render it, and surface the cross-references that echo the same idea in the New Testament. The server returns the BDB definition, the morphological parsing, all five translation renderings, and a set of linked passages — in one response. She picks up the same conversation Friday morning to chase down the Isaiah parallels she bookmarked.
+
+**The seminary student writing an exegesis paper on Ephesians 2:8–9.** He needs to demonstrate awareness of the Greek grammar, the lexical range of *charis*, and how the passage connects to the broader Pauline corpus. He asks for a word study on the Greek for "grace," then separately queries the cross-references to see which passages the OpenBible dataset links to this verse. He uses the semantic search to find thematically related passages that don't share the exact word, and pastes the structured results directly into his annotated bibliography notes. The entire research thread lives in one session so he can pick up the next day without losing context.
+
+**The small group leader preparing a discussion on forgiveness.** She wants more than a keyword search — she wants the topical shape of what the Bible teaches. She opens with Nave's for "forgiveness," scans the subcategories and associated verses, then asks the server to compare how three translations render a verse that surprised her. When her group asks on Thursday night why a particular translation says "pardon" where others say "forgive," she already has the lexical answer ready.
+
+---
+
+### What Responses Look Like
 
 **Word study on "grace" in Ephesians 2:8:**
 
@@ -98,13 +112,3 @@ You are preparing to preach or teach and need cross-references, lexical support,
 > **Psalms** — 28 references across 15 chapters. *Why it matters:* The poetry of lament and trust, where suffering finds voice and faith endures. *Themes matched:* Lament, crying out, divine refuge, trust under affliction. *Suggested anchor passages:* Psalm 23 (confidence), Psalm 42 (deep questioning), Psalm 88 (darkest lament).
 >
 > **Verse results:** 2 Corinthians 1:4 — God comforts us in all our affliction (Nave's: AFFLICTION + Semantic). 1 Peter 4:19 — let those who suffer according to God's will entrust their souls to a faithful Creator (Semantic). Job 1:21 — the Lord gave, and the Lord has taken away; blessed be the name of the Lord (Nave's: SUFFERING).
-
----
-
-## How Subscribers Use It
-
-**The pastor drafting Sunday's sermon on Wednesday afternoon.** She's preaching on Psalm 23 and wants to know how the Hebrew behind "restore my soul" has been translated across history. She asks her AI assistant to pull the Strong's entry for the root verb, compare how KJV, ASV, and YLT each render it, and surface the cross-references that echo the same idea in the New Testament. The server returns the BDB definition, the morphological parsing, all five translation renderings, and a set of linked passages — in one response. She picks up the same conversation Friday morning to chase down the Isaiah parallels she bookmarked.
-
-**The seminary student writing an exegesis paper on Ephesians 2:8–9.** He needs to demonstrate awareness of the Greek grammar, the lexical range of *charis*, and how the passage connects to the broader Pauline corpus. He asks for a word study on the Greek for "grace," then separately queries the cross-references to see which passages the OpenBible dataset links to this verse. He uses the semantic search to find thematically related passages that don't share the exact word, and pastes the structured results directly into his annotated bibliography notes. The entire research thread lives in one session so he can pick up the next day without losing context.
-
-**The small group leader preparing a discussion on forgiveness.** She wants more than a keyword search — she wants the topical shape of what the Bible teaches. She opens with Nave's for "forgiveness," scans the subcategories and associated verses, then asks the server to compare how three translations render a verse that surprised her. When her group asks on Thursday night why a particular translation says "pardon" where others say "forgive," she already has the lexical answer ready.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.11.3",
       "license": "MIT",
       "dependencies": {
-        "@mctx-ai/app": "^1.1.0"
+        "@mctx-ai/mcp": "^2.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
-        "@mctx-ai/dev": "^1.0.0",
+        "@mctx-ai/dev": "^2.0.0",
         "@types/node": "^25.3.5",
         "esbuild": "^0.27.3",
         "eslint": "^9.17.0",
@@ -671,16 +671,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@mctx-ai/app": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/app/-/app-1.1.0.tgz",
-      "integrity": "sha512-XYJsH4GrhCfacmq3Qt5lK5S6oeqZTNYeWxznXUAiscrg+EEn/lgXJq/PcuOHvb7Lhy5dhwwsdfhW5fRueEZlaw==",
-      "license": "MIT"
-    },
     "node_modules/@mctx-ai/dev": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/dev/-/dev-1.0.0.tgz",
-      "integrity": "sha512-tA4uffiPJRBpXA0UNNtwAla3NWYo90RmVjDNwG2B+HtXYQM6gCCtAgFAa+EENdn5L9XO5Sj08703aAF99hbUtQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/dev/-/dev-2.0.0.tgz",
+      "integrity": "sha512-L4URrsuudwdXAEShUR3h09omvYHxCWDp1dPyaxEuKkQJ5DH8iDLFx2ojurQwWD3lcWeMzSz+8/b8en772PgIXg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -690,8 +684,14 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@mctx-ai/app": "^1.0.0"
+        "@mctx-ai/mcp": "^2.0.0"
       }
+    },
+    "node_modules/@mctx-ai/mcp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp/-/mcp-2.0.0.tgz",
+      "integrity": "sha512-NIc8HCrBAs1hD1iVpJjx77Pudnb95PTLlS2+iVrCVYLujfwrxvJ4NQ5BSgWLU8AtuZyBulx/NBnnAnFlIt49Qw==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bible-study",
   "version": "1.11.3",
-  "description": "Study the Bible in its original languages, trace themes across both testaments, and compare five translations — all in one conversation. Ask any question about what Scripture says and get grounded, cited answers: What does the Bible say about suffering? Topical search surfaces Job as the Bible's principal witness on suffering (with explanations of why it matters and suggested starting passages), Psalms on lament, Romans on justification — whole books and narratives alongside individual verses. What is the Hebrew word behind lovingkindness in Psalm 23? Compare how KJV and WEB translate John 3:16. Trace the word grace through Paul's letters. Covers 155,510 verses across KJV, WEB, ASV, YLT, and Darby with 606,140 cross-references, 17,543 Strong's entries, BDB and Thayer lexicon definitions, and Nave's 5,319 topical categories.",
+  "description": "Deep Bible study using semantic search, cross-references, topical search, and translation tools. 155,510 verses with 606,140 cross-references. What does the Bible say about suffering? Topical search surfaces Job as the Bible's principal witness on suffering (with explanations of why it matters and suggested starting passages), Psalms on lament, Romans on justification — whole books and narratives alongside individual verses. What is the Hebrew word behind lovingkindness in Psalm 23? Compare how KJV and WEB translate John 3:16. Trace the word grace through Paul's letters. Covers KJV, WEB, ASV, YLT, and Darby with 17,543 Strong's entries, BDB and Thayer lexicon definitions, and Nave's 5,319 topical categories.",
   "homepage": "https://github.com/mctx-ai/bible-study",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bible-study",
   "version": "1.11.3",
-  "description": "Deep Bible study using semantic search, cross-references, topical search, and translation tools. 155,510 verses with 606,140 cross-references. What does the Bible say about suffering? Topical search surfaces Job as the Bible's principal witness on suffering (with explanations of why it matters and suggested starting passages), Psalms on lament, Romans on justification — whole books and narratives alongside individual verses. What is the Hebrew word behind lovingkindness in Psalm 23? Compare how KJV and WEB translate John 3:16. Trace the word grace through Paul's letters. Covers KJV, WEB, ASV, YLT, and Darby with 17,543 Strong's entries, BDB and Thayer lexicon definitions, and Nave's 5,319 topical categories.",
+  "description": "The best way to Build an MCP Server. Deep Bible study using semantic search, cross-references, topical search, and translation tools. 155,510 verses with 606,140 cross-references. What does the Bible say about suffering? Topical search surfaces Job as the Bible's principal witness on suffering (with explanations of why it matters and suggested starting passages), Psalms on lament, Romans on justification — whole books and narratives alongside individual verses. What is the Hebrew word behind lovingkindness in Psalm 23? Compare how KJV and WEB translate John 3:16. Trace the word grace through Paul's letters. Covers KJV, WEB, ASV, YLT, and Darby with 17,543 Strong's entries, BDB and Thayer lexicon definitions, and Nave's 5,319 topical categories.",
   "homepage": "https://github.com/mctx-ai/bible-study",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --minify --platform=neutral --target=es2020 --format=esm --outfile=dist/index.js",
+    "build": "esbuild src/index.ts --bundle --minify --platform=neutral --target=es2020 --format=esm --external:@mctx-ai/mcp --outfile=dist/index.js",
     "db:schema": "tsx scripts/create-schema.ts",
-    "dev": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/app --sourcemap && run-p dev:build dev:server",
-    "dev:build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/app --watch --sourcemap",
+    "dev": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/mcp --sourcemap && run-p dev:build dev:server",
+    "dev:build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/mcp --watch --sourcemap",
     "dev:server": "mctx-dev dist/index.js",
     "test": "vitest run",
     "lint": "eslint src/",
@@ -57,11 +57,11 @@
     "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.scripts.json"
   },
   "dependencies": {
-    "@mctx-ai/app": "^1.1.0"
+    "@mctx-ai/mcp": "^2.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@mctx-ai/dev": "^1.0.0",
+    "@mctx-ai/dev": "^2.0.0",
     "@types/node": "^25.3.5",
     "esbuild": "^0.27.3",
     "eslint": "^9.17.0",

--- a/scripts/acquire-data.ts
+++ b/scripts/acquire-data.ts
@@ -509,7 +509,7 @@ async function acquireWEB(): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Data Acquisition');
+  console.log('Bible Study MCP Server — Data Acquisition');
   console.log('====================================\n');
 
   fs.mkdirSync(DATA_DIR, { recursive: true });

--- a/scripts/compute-salience.ts
+++ b/scripts/compute-salience.ts
@@ -283,7 +283,7 @@ async function insertSalienceRows(rows: SalienceRow[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Topic Book Salience ETL');
+  console.log('Bible Study MCP Server — Topic Book Salience ETL');
   console.log('==========================================\n');
 
   const required = [

--- a/scripts/create-schema.ts
+++ b/scripts/create-schema.ts
@@ -2,7 +2,7 @@
 /**
  * create-schema.ts
  *
- * Creates all D1 database tables, indexes, and constraints for the Bible Study App.
+ * Creates all D1 database tables, indexes, and constraints for the Bible Study MCP Server.
  *
  * Usage:
  *   npx tsx scripts/create-schema.ts
@@ -274,7 +274,7 @@ async function executeStatements(statements: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — D1 Schema Creation');
+  console.log('Bible Study MCP Server — D1 Schema Creation');
   console.log('=====================================\n');
 
   const all: string[] = [];

--- a/scripts/etl-all.sh
+++ b/scripts/etl-all.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # ===========================================================================
-# etl-all.sh — Run the complete Bible Study App ETL pipeline in order
+# etl-all.sh — Run the complete Bible Study MCP Server ETL pipeline in order
 # ===========================================================================
 
 # ---------------------------------------------------------------------------

--- a/scripts/etl-bible-text.ts
+++ b/scripts/etl-bible-text.ts
@@ -634,7 +634,7 @@ async function loadVerses(
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Bible Text ETL');
+  console.log('Bible Study MCP Server — Bible Text ETL');
   console.log('==================================\n');
 
   // Validate required environment variables

--- a/scripts/etl-crossrefs.ts
+++ b/scripts/etl-crossrefs.ts
@@ -514,7 +514,7 @@ function votesToConfidence(votes: number): number {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Cross-Reference ETL');
+  console.log('Bible Study MCP Server — Cross-Reference ETL');
   console.log('======================================\n');
 
   // Validate required environment variables

--- a/scripts/etl-morphology.ts
+++ b/scripts/etl-morphology.ts
@@ -491,7 +491,7 @@ async function loadMorphologyRows(
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Morphology ETL');
+  console.log('Bible Study MCP Server — Morphology ETL');
   console.log('==================================\n');
 
   // Validate required environment variables

--- a/scripts/etl-naves.ts
+++ b/scripts/etl-naves.ts
@@ -629,7 +629,7 @@ async function fetchExistingVerses(): Promise<Set<string>> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log("Bible Study App — Nave's Topical Bible ETL");
+  console.log("Bible Study MCP Server — Nave's Topical Bible ETL");
   console.log('===========================================\n');
 
   // Validate required environment variables

--- a/scripts/etl-strongs.ts
+++ b/scripts/etl-strongs.ts
@@ -220,7 +220,7 @@ async function loadLexiconEntries(entries: LexiconEntry[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Strong\'s ETL');
+  console.log('Bible Study MCP Server — Strong\'s ETL');
   console.log('=================================\n');
 
   // Validate required environment variables

--- a/scripts/ingest-embeddings.ts
+++ b/scripts/ingest-embeddings.ts
@@ -360,7 +360,7 @@ async function ingestTranslation(translation: TranslationMeta): Promise<void> {
 async function main(): Promise<void> {
   const isResume = process.argv.includes('--resume');
 
-  console.log('Bible Study App — Embedding Ingestion');
+  console.log('Bible Study MCP Server — Embedding Ingestion');
   console.log(`Mode: ${isResume ? 'resume' : 'full re-index'}`);
   console.log('=======================================\n');
 

--- a/scripts/ingest-topic-embeddings.ts
+++ b/scripts/ingest-topic-embeddings.ts
@@ -519,7 +519,7 @@ async function ingestRecordsResume(records: TextRecord[], label: string): Promis
 async function main(): Promise<void> {
   const isResume = process.argv.includes('--resume');
 
-  console.log('Bible Study App — Topic Embedding Ingestion');
+  console.log('Bible Study MCP Server — Topic Embedding Ingestion');
   console.log(`Mode: ${isResume ? 'resume' : 'full re-index'}`);
   console.log('============================================\n');
 

--- a/scripts/populate-fts5.ts
+++ b/scripts/populate-fts5.ts
@@ -2,7 +2,7 @@
 /**
  * populate-fts5.ts
  *
- * Populates (or rebuilds) the FTS5 full-text search index for the Bible Study App.
+ * Populates (or rebuilds) the FTS5 full-text search index for the Bible Study MCP Server.
  *
  * The verses_fts virtual table is a content table backed by the verses table.
  * On first run this script inserts all verse text into the index. On re-runs it
@@ -35,7 +35,7 @@ function log(msg: string): void {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — FTS5 Index Population');
+  console.log('Bible Study MCP Server — FTS5 Index Population');
   console.log('=========================================\n');
 
   const required = ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID', 'D1_DATABASE_ID'];

--- a/scripts/setup-infra.sh
+++ b/scripts/setup-infra.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/setup-infra.sh
 #
-# Sets up Cloudflare infrastructure for the Bible Study App.
+# Sets up Cloudflare infrastructure for the Bible Study MCP Server.
 # Creates a D1 database and a Vectorize index if they don't already exist.
 #
 # Prerequisites:
@@ -63,7 +63,7 @@ else
   WRANGLER="npx wrangler"
 fi
 
-echo "==> Cloudflare infrastructure setup for Bible Study App"
+echo "==> Cloudflare infrastructure setup for Bible Study MCP Server"
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -401,7 +401,7 @@ async function checkDataIntegrity(): Promise<void> {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
-  console.log('Bible Study App — Data Validation');
+  console.log('Bible Study MCP Server — Data Validation');
   console.log('===================================');
 
   try {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -397,332 +397,253 @@ describe('Tool: topical_search', () => {
     }
   });
 
-  test(
-    'handles multi-word thematic queries without crashing',
-    async () => {
-      const queries = [
-        "God's faithfulness during suffering",
-        'innocent suffering',
-        'lament and trust in God',
-        'God working through long periods of suffering',
-      ];
+  test('handles multi-word thematic queries without crashing', async () => {
+    const queries = [
+      "God's faithfulness during suffering",
+      'innocent suffering',
+      'lament and trust in God',
+      'God working through long periods of suffering',
+    ];
 
-      for (const topic of queries) {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    for (const topic of queries) {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result).toBeDefined();
-        expect(Array.isArray(data.result.content)).toBe(true);
-      }
-    },
-    // Each query makes multiple HTTP round-trips (embedding + D1 + Vectorize),
-    // so 4 sequential queries need more than the default 5 s timeout.
-    30_000,
-  );
+      expect(data.result).toBeDefined();
+      expect(Array.isArray(data.result.content)).toBe(true);
+    }
+  }, 30_000); // so 4 sequential queries need more than the default 5 s timeout. // Each query makes multiple HTTP round-trips (embedding + D1 + Vectorize),
 });
 
 describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
   'Tool: topical_search — thematic correctness',
   () => {
-    test(
-      '"suffering" returns Job as a major witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"suffering" returns Job as a major witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Job is the canonical biblical book on suffering — it must appear.
-        expect(witnessBooks).toContain('Job');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Job is the canonical biblical book on suffering — it must appear.
+      expect(witnessBooks).toContain('Job');
+    }, 15_000);
 
-    test(
-      '"innocent suffering" returns Job as a major witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'innocent suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"innocent suffering" returns Job as a major witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'innocent suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Job is the paradigmatic book for innocent suffering — it must appear as a witness.
-        expect(witnessBooks).toContain('Job');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Job is the paradigmatic book for innocent suffering — it must appear as a witness.
+      expect(witnessBooks).toContain('Job');
+    }, 15_000);
 
-    test(
-      '"lament and trust in God" surfaces Psalms',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'lament and trust in God' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"lament and trust in God" surfaces Psalms', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'lament and trust in God' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        expect(witnessBooks).toContain('Psalms');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      expect(witnessBooks).toContain('Psalms');
+    }, 15_000);
 
-    test(
-      'major witnesses include representative verse with text',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'faith' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('major witnesses include representative verse with text', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'faith' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
 
-        for (const witness of parsed.major_witnesses) {
-          expect(witness.representative_verse).toBeDefined();
-          expect(typeof witness.representative_verse.text).toBe('string');
-          expect(witness.representative_verse.text.length).toBeGreaterThan(0);
-          // citation is an object with book, chapter, verse, translation.
-          expect(witness.representative_verse.citation).toBeDefined();
-          expect(typeof witness.representative_verse.citation.book).toBe(
-            'string',
-          );
-        }
-      },
-      15_000,
-    );
+      for (const witness of parsed.major_witnesses) {
+        expect(witness.representative_verse).toBeDefined();
+        expect(typeof witness.representative_verse.text).toBe('string');
+        expect(witness.representative_verse.text.length).toBeGreaterThan(0);
+        // citation is an object with book, chapter, verse, translation.
+        expect(witness.representative_verse.citation).toBeDefined();
+        expect(typeof witness.representative_verse.citation.book).toBe('string');
+      }
+    }, 15_000);
 
-    test(
-      'verse results include at least one from a major witness book',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('verse results include at least one from a major witness book', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
 
-        const witnessBooks = new Set<string>(
-          parsed.major_witnesses.map((w: { book: string }) => w.book),
-        );
-        const resultBooks = parsed.results.map(
-          (r: { citation: { book: string } }) => r.citation.book,
-        );
-        const hasOverlap = resultBooks.some((book: string) =>
-          witnessBooks.has(book),
-        );
-        expect(hasOverlap).toBe(true);
-      },
-      15_000,
-    );
+      const witnessBooks = new Set<string>(
+        parsed.major_witnesses.map((w: { book: string }) => w.book),
+      );
+      const resultBooks = parsed.results.map(
+        (r: { citation: { book: string } }) => r.citation.book,
+      );
+      const hasOverlap = resultBooks.some((book: string) => witnessBooks.has(book));
+      expect(hasOverlap).toBe(true);
+    }, 15_000);
 
-    test(
-      'results include match_reason explanations',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'faith' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('results include match_reason explanations', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'faith' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
 
-        const hasMatchReason = parsed.results.some(
-          (r: { match_reason?: string }) =>
-            typeof r.match_reason === 'string' && r.match_reason.length > 0,
-        );
-        expect(hasMatchReason).toBe(true);
-      },
-      15_000,
-    );
+      const hasMatchReason = parsed.results.some(
+        (r: { match_reason?: string }) =>
+          typeof r.match_reason === 'string' && r.match_reason.length > 0,
+      );
+      expect(hasMatchReason).toBe(true);
+    }, 15_000);
 
-    test(
-      'major witnesses include match_reason',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('major witnesses include match_reason', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
 
-        for (const witness of parsed.major_witnesses) {
-          expect(typeof witness.match_reason).toBe('string');
-          expect(witness.match_reason.length).toBeGreaterThan(0);
-        }
-      },
-      15_000,
-    );
+      for (const witness of parsed.major_witnesses) {
+        expect(typeof witness.match_reason).toBe('string');
+        expect(witness.match_reason.length).toBeGreaterThan(0);
+      }
+    }, 15_000);
 
-    test(
-      '"leadership" surfaces relevant results',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'leadership' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"leadership" surfaces relevant results', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'leadership' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        // Leadership may not meet the major witness threshold (min 5 verses
-        // across 2+ chapters), but should return verse results.
-        expect(parsed.results.length).toBeGreaterThan(0);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      // Leadership may not meet the major witness threshold (min 5 verses
+      // across 2+ chapters), but should return verse results.
+      expect(parsed.results.length).toBeGreaterThan(0);
+    }, 15_000);
 
-    test(
-      '"redemption" matches REDEEM-related topics',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'redemption' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"redemption" matches REDEEM-related topics', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'redemption' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+    }, 15_000);
 
-    test(
-      '"exile and return" surfaces Jeremiah or Ezekiel as witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'exile and return' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"exile and return" surfaces Jeremiah or Ezekiel as witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'exile and return' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Jeremiah and Ezekiel are the primary prophetic witnesses to exile — at least one must appear.
-        const hasExileProphet = witnessBooks.includes('Jeremiah') || witnessBooks.includes('Ezekiel');
-        expect(hasExileProphet).toBe(true);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Jeremiah and Ezekiel are the primary prophetic witnesses to exile — at least one must appear.
+      const hasExileProphet = witnessBooks.includes('Jeremiah') || witnessBooks.includes('Ezekiel');
+      expect(hasExileProphet).toBe(true);
+    }, 15_000);
 
-    test(
-      '"the Holy Spirit" surfaces Acts and John',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'the Holy Spirit' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"the Holy Spirit" surfaces Acts and John', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'the Holy Spirit' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        const expectedBooks = ['Acts', 'John'];
-        const hasExpectedBook = expectedBooks.some((book) =>
-          witnessBooks.includes(book),
-        );
-        expect(hasExpectedBook).toBe(true);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      const expectedBooks = ['Acts', 'John'];
+      const hasExpectedBook = expectedBooks.some((book) => witnessBooks.includes(book));
+      expect(hasExpectedBook).toBe(true);
+    }, 15_000);
 
-    test(
-      '"end times prophecy" surfaces Daniel or Revelation as witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'end times prophecy' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"end times prophecy" surfaces Daniel or Revelation as witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'end times prophecy' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Daniel and Revelation are the canonical apocalyptic books — at least one must appear.
-        const hasApocalypticBook = witnessBooks.includes('Daniel') || witnessBooks.includes('Revelation');
-        expect(hasApocalypticBook).toBe(true);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Daniel and Revelation are the canonical apocalyptic books — at least one must appear.
+      const hasApocalypticBook =
+        witnessBooks.includes('Daniel') || witnessBooks.includes('Revelation');
+      expect(hasApocalypticBook).toBe(true);
+    }, 15_000);
 
-    test(
-      '"God\'s sovereignty over nations" surfaces Isaiah/Daniel',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: "God's sovereignty over nations" },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"God\'s sovereignty over nations" surfaces Isaiah/Daniel', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: "God's sovereignty over nations" },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        const expectedBooks = ['Isaiah', 'Daniel'];
-        const hasExpectedBook = expectedBooks.some((book) =>
-          witnessBooks.includes(book),
-        );
-        expect(hasExpectedBook).toBe(true);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      const expectedBooks = ['Isaiah', 'Daniel'];
+      const hasExpectedBook = expectedBooks.some((book) => witnessBooks.includes(book));
+      expect(hasExpectedBook).toBe(true);
+    }, 15_000);
   },
 );
 
@@ -753,9 +674,7 @@ describe('Tool description routing validation', () => {
       (t: { name: string }) => t.name === 'topical_search',
     );
     expect(topicalTool).toBeDefined();
-    expect(topicalTool.description.toLowerCase()).toContain(
-      'what does the bible say',
-    );
+    expect(topicalTool.description.toLowerCase()).toContain('what does the bible say');
   });
 
   test('tool is registered as "semantic_search" not "search_bible"', async () => {
@@ -838,12 +757,8 @@ describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
       expect(parsed1.results.length).toBe(parsed2.results.length);
 
       // Same citations in same order
-      const citations1 = parsed1.results.map(
-        (r: { citation: string }) => r.citation,
-      );
-      const citations2 = parsed2.results.map(
-        (r: { citation: string }) => r.citation,
-      );
+      const citations1 = parsed1.results.map((r: { citation: string }) => r.citation);
+      const citations2 = parsed2.results.map((r: { citation: string }) => r.citation);
       expect(citations1).toEqual(citations2);
     });
   },
@@ -857,277 +772,228 @@ describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
 describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
   'Tool: topical_search — expanded thematic coverage',
   () => {
-    test(
-      '"God\'s faithfulness during suffering" surfaces Job as a witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: "God's faithfulness during suffering" },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"God\'s faithfulness during suffering" surfaces Job as a witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: "God's faithfulness during suffering" },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Job directly addresses God's faithfulness through prolonged suffering.
-        expect(witnessBooks).toContain('Job');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Job directly addresses God's faithfulness through prolonged suffering.
+      expect(witnessBooks).toContain('Job');
+    }, 15_000);
 
-    test(
-      '"God\'s faithfulness during suffering" surfaces Psalms as a witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: "God's faithfulness during suffering" },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"God\'s faithfulness during suffering" surfaces Psalms as a witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: "God's faithfulness during suffering" },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Psalms extensively records God's faithfulness amid lament and suffering.
-        expect(witnessBooks).toContain('Psalms');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Psalms extensively records God's faithfulness amid lament and suffering.
+      expect(witnessBooks).toContain('Psalms');
+    }, 15_000);
 
-    test(
-      '"innocent suffering" returns results and witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'innocent suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"innocent suffering" returns results and witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'innocent suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+    }, 15_000);
 
-    test(
-      '"lament and sorrow" surfaces Psalms and Lamentations as witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'lament and sorrow' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"lament and sorrow" surfaces Psalms and Lamentations as witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'lament and sorrow' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Psalms and Lamentations are the canonical lament literature — both must appear.
-        expect(witnessBooks).toContain('Psalms');
-        expect(witnessBooks).toContain('Lamentations');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Psalms and Lamentations are the canonical lament literature — both must appear.
+      expect(witnessBooks).toContain('Psalms');
+      expect(witnessBooks).toContain('Lamentations');
+    }, 15_000);
 
-    test(
-      '"comfort in affliction" surfaces Isaiah as a witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'comfort in affliction' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"comfort in affliction" surfaces Isaiah as a witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'comfort in affliction' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.results.length).toBeGreaterThan(0);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Isaiah's "comfort, comfort my people" passages are central to this topic.
-        expect(witnessBooks).toContain('Isaiah');
-      },
-      15_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Isaiah's "comfort, comfort my people" passages are central to this topic.
+      expect(witnessBooks).toContain('Isaiah');
+    }, 15_000);
 
-    test(
-      'major witnesses have why_this_book_matters field populated',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('major witnesses have why_this_book_matters field populated', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
 
-        for (const witness of parsed.major_witnesses) {
-          expect(typeof witness.why_this_book_matters).toBe('string');
-          expect(witness.why_this_book_matters.length).toBeGreaterThan(0);
+      for (const witness of parsed.major_witnesses) {
+        expect(typeof witness.why_this_book_matters).toBe('string');
+        expect(witness.why_this_book_matters.length).toBeGreaterThan(0);
+      }
+
+      // Job is the canonical book on suffering — it must appear as a witness
+      // and have a non-empty why_this_book_matters string.
+      const job = parsed.major_witnesses.find((w: { book: string }) => w.book === 'Job');
+      expect(job).toBeDefined();
+      expect(typeof job.why_this_book_matters).toBe('string');
+      expect(job.why_this_book_matters.length).toBeGreaterThan(0);
+      // The message must mention the book name.
+      expect(job.why_this_book_matters).toContain('Job');
+    }, 15_000);
+
+    test('major witnesses have themes_matched field populated', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
+
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+
+      for (const witness of parsed.major_witnesses) {
+        expect(Array.isArray(witness.themes_matched)).toBe(true);
+        expect(witness.themes_matched.length).toBeGreaterThan(0);
+        for (const theme of witness.themes_matched) {
+          expect(typeof theme).toBe('string');
         }
+      }
 
-        // Job is the canonical book on suffering — it must appear as a witness
-        // and have a non-empty why_this_book_matters string.
-        const job = parsed.major_witnesses.find(
-          (w: { book: string }) => w.book === 'Job',
-        );
-        expect(job).toBeDefined();
-        expect(typeof job.why_this_book_matters).toBe('string');
-        expect(job.why_this_book_matters.length).toBeGreaterThan(0);
-        // The message must mention the book name.
-        expect(job.why_this_book_matters).toContain('Job');
-      },
-      15_000,
-    );
+      // At least one witness must have a theme_matched that mentions
+      // "suffering" or "affliction" (case-insensitive) — confirming the
+      // themes are query-relevant, not generic.
+      const allThemes: string[] = parsed.major_witnesses.flatMap(
+        (w: { themes_matched: string[] }) => w.themes_matched,
+      );
+      const hasRelevantTheme = allThemes.some((t) => {
+        const lower = t.toLowerCase();
+        return lower.includes('suffering') || lower.includes('affliction');
+      });
+      expect(hasRelevantTheme).toBe(true);
+    }, 15_000);
 
-    test(
-      'major witnesses have themes_matched field populated',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('major witnesses have suggested_anchor_passages field', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'suffering' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
 
-        for (const witness of parsed.major_witnesses) {
-          expect(Array.isArray(witness.themes_matched)).toBe(true);
-          expect(witness.themes_matched.length).toBeGreaterThan(0);
-          for (const theme of witness.themes_matched) {
-            expect(typeof theme).toBe('string');
-          }
+      for (const witness of parsed.major_witnesses) {
+        expect(Array.isArray(witness.suggested_anchor_passages)).toBe(true);
+        for (const passage of witness.suggested_anchor_passages) {
+          expect(typeof passage).toBe('string');
         }
+      }
 
-        // At least one witness must have a theme_matched that mentions
-        // "suffering" or "affliction" (case-insensitive) — confirming the
-        // themes are query-relevant, not generic.
-        const allThemes: string[] = parsed.major_witnesses.flatMap(
-          (w: { themes_matched: string[] }) => w.themes_matched,
-        );
-        const hasRelevantTheme = allThemes.some((t) => {
-          const lower = t.toLowerCase();
-          return lower.includes('suffering') || lower.includes('affliction');
-        });
-        expect(hasRelevantTheme).toBe(true);
-      },
-      15_000,
-    );
+      // At least one witness must have non-empty suggested_anchor_passages.
+      const hasPassages = parsed.major_witnesses.some(
+        (w: { suggested_anchor_passages: string[] }) => w.suggested_anchor_passages.length > 0,
+      );
+      expect(hasPassages).toBe(true);
 
-    test(
-      'major witnesses have suggested_anchor_passages field',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'suffering' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
-
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-
-        for (const witness of parsed.major_witnesses) {
-          expect(Array.isArray(witness.suggested_anchor_passages)).toBe(true);
-          for (const passage of witness.suggested_anchor_passages) {
-            expect(typeof passage).toBe('string');
-          }
+      // Most passage references contain a number (e.g. "Job 1", "Job 1:21").
+      // Short books (4 chapters or fewer) may return just the book name when
+      // topic coverage spans the whole book — so we don't require a digit on
+      // every entry, only that the string is non-empty and contains the book name.
+      const allPassages: string[] = parsed.major_witnesses.flatMap(
+        (w: { suggested_anchor_passages: string[]; book: string }) => w.suggested_anchor_passages,
+      );
+      for (const witness of parsed.major_witnesses) {
+        for (const passage of witness.suggested_anchor_passages) {
+          expect(typeof passage).toBe('string');
+          expect(passage.length).toBeGreaterThan(0);
+          // Passage must reference the witness's own book.
+          expect(passage).toContain(witness.book);
         }
+      }
+      // At least one passage across all witnesses should contain a number.
+      const passagesWithNumbers = allPassages.filter((p) => /\d/.test(p));
+      if (allPassages.length > 0) {
+        expect(passagesWithNumbers.length).toBeGreaterThan(0);
+      }
+    }, 15_000);
 
-        // At least one witness must have non-empty suggested_anchor_passages.
-        const hasPassages = parsed.major_witnesses.some(
-          (w: { suggested_anchor_passages: string[] }) =>
-            w.suggested_anchor_passages.length > 0,
-        );
-        expect(hasPassages).toBe(true);
+    test('narrative_reason field exists on major witnesses (string or undefined)', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'providence' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        // Most passage references contain a number (e.g. "Job 1", "Job 1:21").
-        // Short books (4 chapters or fewer) may return just the book name when
-        // topic coverage spans the whole book — so we don't require a digit on
-        // every entry, only that the string is non-empty and contains the book name.
-        const allPassages: string[] = parsed.major_witnesses.flatMap(
-          (w: { suggested_anchor_passages: string[]; book: string }) =>
-            w.suggested_anchor_passages,
-        );
-        for (const witness of parsed.major_witnesses) {
-          for (const passage of witness.suggested_anchor_passages) {
-            expect(typeof passage).toBe('string');
-            expect(passage.length).toBeGreaterThan(0);
-            // Passage must reference the witness's own book.
-            expect(passage).toContain(witness.book);
-          }
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+
+      // narrative_reason is optional — witnesses with a narrative arc get it,
+      // others do not. Validate the field is either a non-empty string or absent.
+      for (const witness of parsed.major_witnesses) {
+        if (witness.narrative_reason !== undefined) {
+          expect(typeof witness.narrative_reason).toBe('string');
+          expect(witness.narrative_reason.length).toBeGreaterThan(0);
         }
-        // At least one passage across all witnesses should contain a number.
-        const passagesWithNumbers = allPassages.filter((p) => /\d/.test(p));
-        if (allPassages.length > 0) {
-          expect(passagesWithNumbers.length).toBeGreaterThan(0);
-        }
-      },
-      15_000,
-    );
+      }
 
-    test(
-      'narrative_reason field exists on major witnesses (string or undefined)',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'providence' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
-
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-
-        // narrative_reason is optional — witnesses with a narrative arc get it,
-        // others do not. Validate the field is either a non-empty string or absent.
-        for (const witness of parsed.major_witnesses) {
-          if (witness.narrative_reason !== undefined) {
-            expect(typeof witness.narrative_reason).toBe('string');
-            expect(witness.narrative_reason.length).toBeGreaterThan(0);
-          }
-        }
-
-        // The field must exist as a key on the object (present or undefined),
-        // confirming the serialization includes it when set.
-        const witnessesWithNarrative = parsed.major_witnesses.filter(
-          (w: { narrative_reason?: string }) =>
-            w.narrative_reason !== undefined,
-        );
-        // Not asserting count — just that any present value is a non-empty string.
-        for (const w of witnessesWithNarrative) {
-          expect(typeof w.narrative_reason).toBe('string');
-          expect(w.narrative_reason.length).toBeGreaterThan(0);
-        }
-      },
-      15_000,
-    );
+      // The field must exist as a key on the object (present or undefined),
+      // confirming the serialization includes it when set.
+      const witnessesWithNarrative = parsed.major_witnesses.filter(
+        (w: { narrative_reason?: string }) => w.narrative_reason !== undefined,
+      );
+      // Not asserting count — just that any present value is a non-empty string.
+      for (const w of witnessesWithNarrative) {
+        expect(typeof w.narrative_reason).toBe('string');
+        expect(w.narrative_reason.length).toBeGreaterThan(0);
+      }
+    }, 15_000);
   },
 );
 
@@ -1140,150 +1006,122 @@ describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
 describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
   'Tool: topical_search — story grounding',
   () => {
-    test(
-      '"Noah and the ark" returns Genesis as the central witness',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'Noah and the ark' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"Noah and the ark" returns Genesis as the central witness', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'Noah and the ark' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Genesis is the canonical narrative home of the Noah story.
-        expect(witnessBooks).toContain('Genesis');
-        // Genesis must be the first (central) witness.
-        expect(witnessBooks[0]).toBe('Genesis');
-      },
-      20_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Genesis is the canonical narrative home of the Noah story.
+      expect(witnessBooks).toContain('Genesis');
+      // Genesis must be the first (central) witness.
+      expect(witnessBooks[0]).toBe('Genesis');
+    }, 20_000);
 
-    test(
-      '"Noah and the ark" anchor passages fall within Genesis 5–9',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'Noah and the ark' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"Noah and the ark" anchor passages fall within Genesis 5–9', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'Noah and the ark' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        const genesis = parsed.major_witnesses.find(
-          (w: { book: string }) => w.book === 'Genesis',
-        );
-        expect(genesis).toBeDefined();
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      const genesis = parsed.major_witnesses.find((w: { book: string }) => w.book === 'Genesis');
+      expect(genesis).toBeDefined();
 
-        // Anchor passages must reference Genesis and fall within chapters 5–9.
-        // The Noah narrative spans Genesis 6–9 (the flood account proper), with
-        // the genealogy in chapter 5. Any anchor passage outside this range
-        // (e.g. Genesis 22, 46) indicates story grounding is broken.
-        const passages: string[] = genesis.suggested_anchor_passages ?? [];
-        expect(passages.length).toBeGreaterThan(0);
-        for (const passage of passages) {
-          expect(passage).toContain('Genesis');
-          // Extract chapter numbers from passage strings like "Genesis 6-9" or "Genesis 7"
-          const chapterMatches = passage.match(/Genesis (\d+)/g) ?? [];
-          for (const match of chapterMatches) {
-            const chapter = parseInt(match.replace('Genesis ', ''), 10);
-            expect(chapter).toBeGreaterThanOrEqual(5);
-            expect(chapter).toBeLessThanOrEqual(9);
-          }
+      // Anchor passages must reference Genesis and fall within chapters 5–9.
+      // The Noah narrative spans Genesis 6–9 (the flood account proper), with
+      // the genealogy in chapter 5. Any anchor passage outside this range
+      // (e.g. Genesis 22, 46) indicates story grounding is broken.
+      const passages: string[] = genesis.suggested_anchor_passages ?? [];
+      expect(passages.length).toBeGreaterThan(0);
+      for (const passage of passages) {
+        expect(passage).toContain('Genesis');
+        // Extract chapter numbers from passage strings like "Genesis 6-9" or "Genesis 7"
+        const chapterMatches = passage.match(/Genesis (\d+)/g) ?? [];
+        for (const match of chapterMatches) {
+          const chapter = parseInt(match.replace('Genesis ', ''), 10);
+          expect(chapter).toBeGreaterThanOrEqual(5);
+          expect(chapter).toBeLessThanOrEqual(9);
         }
-      },
-      20_000,
-    );
+      }
+    }, 20_000);
 
-    test(
-      '"Noah and the ark" does NOT include Exodus or Numbers as witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'Noah and the ark' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"Noah and the ark" does NOT include Exodus or Numbers as witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'Noah and the ark' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Exodus and Numbers have no direct Noah/Flood/Ark content.
+      // They must not appear as witnesses (they accumulate co-occurring topic
+      // hits from covenant/sacrifice topics shared with Noah topics).
+      expect(witnessBooks).not.toContain('Exodus');
+      expect(witnessBooks).not.toContain('Numbers');
+    }, 20_000);
+
+    test('"Noah and the ark" allows Hebrews or 1 Peter as secondary witnesses', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: 'Noah and the ark' },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
+
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      const witnessBooks: string[] = parsed.major_witnesses.map((w: { book: string }) => w.book);
+      // Hebrews 11:7 and 1 Peter 3:20 are legitimate direct references
+      // to Noah. At least one should appear as a secondary witness.
+      // This test is a soft assertion (toSatisfy) — it verifies the
+      // filter doesn't over-exclude legitimate interpretive witnesses.
+      const hasLegitimateSecondary =
+        witnessBooks.includes('Hebrews') || witnessBooks.includes('1 Peter');
+      // Not a hard failure — log the result for visibility.
+      if (!hasLegitimateSecondary) {
+        console.warn(
+          '[test] Noah query: Hebrews/1 Peter not in witnesses — acceptable if Genesis dominates correctly.',
+          witnessBooks,
         );
-        // Exodus and Numbers have no direct Noah/Flood/Ark content.
-        // They must not appear as witnesses (they accumulate co-occurring topic
-        // hits from covenant/sacrifice topics shared with Noah topics).
-        expect(witnessBooks).not.toContain('Exodus');
-        expect(witnessBooks).not.toContain('Numbers');
-      },
-      20_000,
-    );
+      }
+      // Genesis must still be present regardless.
+      expect(witnessBooks).toContain('Genesis');
+    }, 20_000);
 
-    test(
-      '"Noah and the ark" allows Hebrews or 1 Peter as secondary witnesses',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: 'Noah and the ark' },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
+    test('"God\'s faithfulness during suffering" themes_matched does not include "the church" (regression)', async () => {
+      const req = createRequest('tools/call', {
+        name: 'topical_search',
+        arguments: { topic: "God's faithfulness during suffering" },
+      });
+      const res = await server.fetch(req);
+      const data = await getResponse(res);
 
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        const witnessBooks: string[] = parsed.major_witnesses.map(
-          (w: { book: string }) => w.book,
-        );
-        // Hebrews 11:7 and 1 Peter 3:20 are legitimate direct references
-        // to Noah. At least one should appear as a secondary witness.
-        // This test is a soft assertion (toSatisfy) — it verifies the
-        // filter doesn't over-exclude legitimate interpretive witnesses.
-        const hasLegitimateSecondary =
-          witnessBooks.includes('Hebrews') || witnessBooks.includes('1 Peter');
-        // Not a hard failure — log the result for visibility.
-        if (!hasLegitimateSecondary) {
-          console.warn(
-            '[test] Noah query: Hebrews/1 Peter not in witnesses — acceptable if Genesis dominates correctly.',
-            witnessBooks,
-          );
-        }
-        // Genesis must still be present regardless.
-        expect(witnessBooks).toContain('Genesis');
-      },
-      20_000,
-    );
+      expect(data.result.isError).toBeFalsy();
+      const parsed = JSON.parse(data.result.content[0].text);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
 
-    test(
-      '"God\'s faithfulness during suffering" themes_matched does not include "the church" (regression)',
-      async () => {
-        const req = createRequest('tools/call', {
-          name: 'topical_search',
-          arguments: { topic: "God's faithfulness during suffering" },
-        });
-        const res = await server.fetch(req);
-        const data = await getResponse(res);
-
-        expect(data.result.isError).toBeFalsy();
-        const parsed = JSON.parse(data.result.content[0].text);
-        expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-
-        // "the church" is a noisy co-occurring theme label that appears via the
-        // CHURCH topic. It co-occurs with suffering topics but is not thematically
-        // relevant to a faithfulness-during-suffering query. The stricter 0.8
-        // threshold for co-occurring topics should prevent it from appearing.
-        const allThemes: string[] = parsed.major_witnesses.flatMap(
-          (w: { themes_matched?: string[] }) => w.themes_matched ?? [],
-        );
-        expect(allThemes).not.toContain('the church');
-      },
-      20_000,
-    );
+      // "the church" is a noisy co-occurring theme label that appears via the
+      // CHURCH topic. It co-occurs with suffering topics but is not thematically
+      // relevant to a faithfulness-during-suffering query. The stricter 0.8
+      // threshold for co-occurring topics should prevent it from appearing.
+      const allThemes: string[] = parsed.major_witnesses.flatMap(
+        (w: { themes_matched?: string[] }) => w.themes_matched ?? [],
+      );
+      expect(allThemes).not.toContain('the church');
+    }, 20_000);
   },
 );
 
@@ -1295,15 +1133,18 @@ describe.skipIf(!process.env.CLOUDFLARE_ACCOUNT_ID)(
 
 describe('Genre-aware explanation templates', () => {
   // Minimal WitnessCandidate factory for testing.
-  function makeCandidate(bookName: string, overrides?: Partial<{
-    book_id: number;
-    testament: string;
-    verse_count: number;
-    chapter_count: number;
-    min_chapter: number;
-    max_chapter: number;
-    topic_names: string;
-  }>) {
+  function makeCandidate(
+    bookName: string,
+    overrides?: Partial<{
+      book_id: number;
+      testament: string;
+      verse_count: number;
+      chapter_count: number;
+      min_chapter: number;
+      max_chapter: number;
+      topic_names: string;
+    }>,
+  ) {
     return {
       book_id: 1,
       book_name: bookName,
@@ -1398,23 +1239,38 @@ describe('Genre-aware explanation templates', () => {
       const themes = ['suffering'];
       const psalmResult = buildWhyThisBookMatters(
         makeCandidate('Psalms'),
-        emptyMap, emptyIds, emptyTopics, themes,
+        emptyMap,
+        emptyIds,
+        emptyTopics,
+        themes,
       );
       const jobResult = buildWhyThisBookMatters(
         makeCandidate('Job'),
-        emptyMap, emptyIds, emptyTopics, themes,
+        emptyMap,
+        emptyIds,
+        emptyTopics,
+        themes,
       );
       const isaiahResult = buildWhyThisBookMatters(
         makeCandidate('Isaiah'),
-        emptyMap, emptyIds, emptyTopics, themes,
+        emptyMap,
+        emptyIds,
+        emptyTopics,
+        themes,
       );
       const romansResult = buildWhyThisBookMatters(
         makeCandidate('Romans'),
-        emptyMap, emptyIds, emptyTopics, themes,
+        emptyMap,
+        emptyIds,
+        emptyTopics,
+        themes,
       );
       const johnResult = buildWhyThisBookMatters(
         makeCandidate('John'),
-        emptyMap, emptyIds, emptyTopics, themes,
+        emptyMap,
+        emptyIds,
+        emptyTopics,
+        themes,
       );
 
       // All five should be distinct strings.
@@ -1428,7 +1284,10 @@ describe('Genre-aware explanation templates', () => {
       for (const book of books) {
         const result = buildWhyThisBookMatters(
           makeCandidate(book),
-          emptyMap, emptyIds, emptyTopics, ['faith'],
+          emptyMap,
+          emptyIds,
+          emptyTopics,
+          ['faith'],
         );
         expect(result).not.toMatch(/concentrates on .+, with \d+ topical references spanning/);
       }
@@ -1437,51 +1296,43 @@ describe('Genre-aware explanation templates', () => {
 
   describe('buildWitnessMatchReason', () => {
     test('Poetry genre (Psalms) mentions prayer or lament', () => {
-      const result = buildWitnessMatchReason(
-        makeCandidate('Psalms'),
-        undefined,
-        ['lament', 'trust'],
-      );
+      const result = buildWitnessMatchReason(makeCandidate('Psalms'), undefined, [
+        'lament',
+        'trust',
+      ]);
       expect(result).toContain('Psalms');
       expect(result).toMatch(/prayer|lament|praise|trust/i);
     });
 
     test('Epistle genre (Ephesians) mentions teaching or doctrinal', () => {
-      const result = buildWitnessMatchReason(
-        makeCandidate('Ephesians'),
-        undefined,
-        ['grace', 'faith'],
-      );
+      const result = buildWitnessMatchReason(makeCandidate('Ephesians'), undefined, [
+        'grace',
+        'faith',
+      ]);
       expect(result).toContain('Ephesians');
       expect(result).toMatch(/teaches|doctrinal|pastoral/i);
     });
 
     test('Prophecy genre (Jeremiah) mentions proclamation or promise', () => {
-      const result = buildWitnessMatchReason(
-        makeCandidate('Jeremiah'),
-        undefined,
-        ['exile', 'restoration'],
-      );
+      const result = buildWitnessMatchReason(makeCandidate('Jeremiah'), undefined, [
+        'exile',
+        'restoration',
+      ]);
       expect(result).toContain('Jeremiah');
       expect(result).toMatch(/prophetic|proclamation|judgment|promise|restoration/i);
     });
 
     test('Gospel genre with narrative uses life-and-ministry language', () => {
-      const result = buildWitnessMatchReason(
-        makeCandidate('Luke'),
-        'Passion',
-        ['redemption', 'sacrifice'],
-      );
+      const result = buildWitnessMatchReason(makeCandidate('Luke'), 'Passion', [
+        'redemption',
+        'sacrifice',
+      ]);
       expect(result).toContain('Luke');
       expect(result).toMatch(/life|ministry|Jesus|Gospel/i);
     });
 
     test('History genre narrative uses story-arc language', () => {
-      const result = buildWitnessMatchReason(
-        makeCandidate('1 Samuel'),
-        'David',
-        ['kingship'],
-      );
+      const result = buildWitnessMatchReason(makeCandidate('1 Samuel'), 'David', ['kingship']);
       expect(result).toContain('1 Samuel');
       expect(result).toMatch(/narrative|historical|story/i);
     });
@@ -1720,10 +1571,10 @@ describe('Genre-aware clustering (clusterToPassageRanges)', () => {
     test('History genre produces references spanning beginning, middle, and end', () => {
       // Genesis has 50 chapters. Arc thirds: 1-17, 18-34, 35-50.
       const rows = makeRows([
-        { chapter: 2, hit_count: 8 },   // entry arc
-        { chapter: 22, hit_count: 10 },  // crisis arc
-        { chapter: 45, hit_count: 7 },   // resolution arc
-        { chapter: 37, hit_count: 6 },   // resolution arc
+        { chapter: 2, hit_count: 8 }, // entry arc
+        { chapter: 22, hit_count: 10 }, // crisis arc
+        { chapter: 45, hit_count: 7 }, // resolution arc
+        { chapter: 37, hit_count: 6 }, // resolution arc
       ]);
       const result = clusterToPassageRanges(rows, 'Genesis', 50, 'History');
       expect(result.length).toBeGreaterThan(0);
@@ -1737,8 +1588,8 @@ describe('Genre-aware clustering (clusterToPassageRanges)', () => {
     test('Gospel genre uses arc strategy', () => {
       // Matthew has 28 chapters. Arc thirds: 1-10, 11-19, 20-28.
       const rows = makeRows([
-        { chapter: 5, hit_count: 12 },  // entry arc (Sermon on the Mount)
-        { chapter: 16, hit_count: 9 },  // crisis arc
+        { chapter: 5, hit_count: 12 }, // entry arc (Sermon on the Mount)
+        { chapter: 16, hit_count: 9 }, // crisis arc
         { chapter: 26, hit_count: 11 }, // resolution arc (Passion narrative)
       ]);
       const result = clusterToPassageRanges(rows, 'Matthew', 28, 'Gospel');
@@ -1767,12 +1618,18 @@ describe('Genre-aware clustering (clusterToPassageRanges)', () => {
     test('consolation query biases toward latter half of prophetic book', () => {
       // Isaiah has 66 chapters. Midpoint = 33. Consolation is chapters 34-66.
       const rows = makeRows([
-        { chapter: 5, hit_count: 8 },    // judgment section (first half)
-        { chapter: 40, hit_count: 10 },  // consolation section (second half)
-        { chapter: 53, hit_count: 12 },  // consolation section (second half)
-        { chapter: 60, hit_count: 9 },   // consolation section (second half)
+        { chapter: 5, hit_count: 8 }, // judgment section (first half)
+        { chapter: 40, hit_count: 10 }, // consolation section (second half)
+        { chapter: 53, hit_count: 12 }, // consolation section (second half)
+        { chapter: 60, hit_count: 9 }, // consolation section (second half)
       ]);
-      const comfort = clusterToPassageRanges(rows, 'Isaiah', 66, 'Prophecy', 'comfort in affliction');
+      const comfort = clusterToPassageRanges(
+        rows,
+        'Isaiah',
+        66,
+        'Prophecy',
+        'comfort in affliction',
+      );
       // Should prefer consolation chapters (>33) over judgment chapters.
       const hasConsolation = comfort.some((p) => {
         const match = p.match(/Isaiah (\d+)/);
@@ -1783,9 +1640,9 @@ describe('Genre-aware clustering (clusterToPassageRanges)', () => {
 
     test('non-consolation query uses density (returns densest chapters)', () => {
       const rows = makeRows([
-        { chapter: 5, hit_count: 15 },  // dense judgment section
+        { chapter: 5, hit_count: 15 }, // dense judgment section
         { chapter: 6, hit_count: 14 },
-        { chapter: 40, hit_count: 4 },  // sparse consolation
+        { chapter: 40, hit_count: 4 }, // sparse consolation
       ]);
       const judgment = clusterToPassageRanges(rows, 'Isaiah', 66, 'Prophecy', 'idolatry');
       // Should use density, not consolation bias — picks chapters 5-6.
@@ -1899,13 +1756,7 @@ describe('isConsolationQuery', () => {
 
 describe('computeQueryAlignmentScore', () => {
   test('returns 0 when there are no matched topics and no semantic hits', () => {
-    const score = computeQueryAlignmentScore(
-      1,
-      [],
-      new Map(),
-      new Map(),
-      0,
-    );
+    const score = computeQueryAlignmentScore(1, [], new Map(), new Map(), 0);
     expect(score).toBe(0);
   });
 
@@ -1917,7 +1768,7 @@ describe('computeQueryAlignmentScore', () => {
       [10],
       relevance,
       new Map(), // no semantic hits
-      5,         // maxSemanticHits > 0 so normalization is valid
+      5, // maxSemanticHits > 0 so normalization is valid
     );
     // A = 1.0 (avg weight), B = 0 (no hits). Final = 0.5*1.0 + 0.5*0 = 0.5
     expect(score).toBeCloseTo(0.5);
@@ -1938,7 +1789,10 @@ describe('computeQueryAlignmentScore', () => {
   });
 
   test('returns 1.0 when both topic alignment and semantic density are perfect', () => {
-    const relevance = new Map([[10, 1.0], [11, 1.0]]);
+    const relevance = new Map([
+      [10, 1.0],
+      [11, 1.0],
+    ]);
     const hitsPerBook = new Map([[5, 8]]);
     const score = computeQueryAlignmentScore(
       5,
@@ -1964,7 +1818,10 @@ describe('computeQueryAlignmentScore', () => {
 
   test('a book with more semantic hits scores higher than one with fewer (same topic alignment)', () => {
     const relevance = new Map([[10, 1.0]]);
-    const hitsPerBook = new Map([[1, 2], [2, 8]]);
+    const hitsPerBook = new Map([
+      [1, 2],
+      [2, 8],
+    ]);
     const maxHits = 8;
 
     const scoreWithFewHits = computeQueryAlignmentScore(1, [10], relevance, hitsPerBook, maxHits);
@@ -1973,8 +1830,16 @@ describe('computeQueryAlignmentScore', () => {
   });
 
   test('query-alignment score is in [0, 1] range for arbitrary inputs', () => {
-    const relevance = new Map([[1, 0.7], [2, 0.9], [3, 0.3]]);
-    const hitsPerBook = new Map([[100, 5], [101, 3], [102, 0]]);
+    const relevance = new Map([
+      [1, 0.7],
+      [2, 0.9],
+      [3, 0.3],
+    ]);
+    const hitsPerBook = new Map([
+      [100, 5],
+      [101, 3],
+      [102, 0],
+    ]);
 
     for (const bookId of [100, 101, 102]) {
       const score = computeQueryAlignmentScore(bookId, [1, 2, 3], relevance, hitsPerBook, 5);
@@ -1991,13 +1856,25 @@ describe('buildQueryAlignmentNote', () => {
   });
 
   test('mentions the query topic in the output', () => {
-    const note = buildQueryAlignmentNote('Psalms', "God's faithfulness during suffering", ['faithfulness', 'lament'], 3, 0.7);
+    const note = buildQueryAlignmentNote(
+      'Psalms',
+      "God's faithfulness during suffering",
+      ['faithfulness', 'lament'],
+      3,
+      0.7,
+    );
     expect(note).toContain("God's faithfulness during suffering");
   });
 
   test('uses strong-signal phrasing when both signals are high', () => {
     // semanticHits >= 2 AND queryAlignmentScore >= 0.6 → both signals fired
-    const note = buildQueryAlignmentNote('Romans', 'justification by faith', ['justification', 'faith'], 4, 0.75);
+    const note = buildQueryAlignmentNote(
+      'Romans',
+      'justification by faith',
+      ['justification', 'faith'],
+      4,
+      0.75,
+    );
     expect(note).toMatch(/aligns closely|both curated|semantic verse/i);
   });
 
@@ -2009,7 +1886,13 @@ describe('buildQueryAlignmentNote', () => {
 
   test('uses topic-only phrasing when topic alignment is high but no semantic hits', () => {
     // queryAlignmentScore >= 0.6 but semanticHits < 2
-    const note = buildQueryAlignmentNote('Isaiah', 'comfort in affliction', ['comfort', 'restoration'], 0, 0.8);
+    const note = buildQueryAlignmentNote(
+      'Isaiah',
+      'comfort in affliction',
+      ['comfort', 'restoration'],
+      0,
+      0.8,
+    );
     expect(note).toMatch(/curated topics|directly named|topically grounded/i);
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,7 +49,8 @@ function createRequest(method: string, params: Record<string, unknown> = {}) {
 }
 
 // Helper to parse JSON-RPC response
-async function getResponse(response: Response) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getResponse(response: any): Promise<any> {
   const data = await response.json();
   return data;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Bible Study App
+ * Bible Study MCP Server
  *
  * Built with @mctx-ai/app. Provides Bible text lookup, semantic search,
  * cross-references, word study, concordance, and topical discovery across 5

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 /**
  * Bible Study MCP Server
  *
- * Built with @mctx-ai/app. Provides Bible text lookup, semantic search,
+ * Built with @mctx-ai/mcp. Provides Bible text lookup, semantic search,
  * cross-references, word study, concordance, and topical discovery across 5
  * public domain translations (KJV, WEB, ASV, YLT, Darby).
  *
  * Version 1.6.4
  */
 
-import { createServer } from '@mctx-ai/app';
+import { createServer } from '@mctx-ai/mcp';
 
 // ─── Lib ──────────────────────────────────────────────────────────────────────
 //

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -51,7 +51,8 @@ function createRequest(method: string, params: Record<string, unknown> = {}) {
 }
 
 // Helper to parse JSON-RPC response
-async function getResponse(response: Response) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getResponse(response: any): Promise<any> {
   const data = await response.json();
   return data;
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for the Bible Study App.
+ * Integration tests for the Bible Study MCP Server.
  *
  * These tests call live Cloudflare APIs (D1, Vectorize, Workers AI) and require
  * CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN environment variables to run.
@@ -65,9 +65,7 @@ async function callTool(name: string, args: Record<string, unknown>) {
 }
 
 // Helper to parse the text content from a successful tool response
-function parseContent(data: {
-  result: { isError?: boolean; content?: { text: string }[] };
-}) {
+function parseContent(data: { result: { isError?: boolean; content?: { text: string }[] } }) {
   expect(data.result.isError).toBeFalsy();
   expect(data.result.content).toBeDefined();
   expect(Array.isArray(data.result.content)).toBe(true);
@@ -86,15 +84,19 @@ describe.skipIf(!hasCredentials)('Integration: topical_search', () => {
     expect(parsed.results.length).toBeGreaterThan(0);
   });
 
-  test('topical_search("love") returns results with major_witnesses', { timeout: 30_000 }, async () => {
-    const data = await callTool('topical_search', { topic: 'love' });
-    const parsed = parseContent(data);
+  test(
+    'topical_search("love") returns results with major_witnesses',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('topical_search', { topic: 'love' });
+      const parsed = parseContent(data);
 
-    expect(Array.isArray(parsed.results)).toBe(true);
-    expect(parsed.results.length).toBeGreaterThan(0);
-    expect(Array.isArray(parsed.major_witnesses)).toBe(true);
-    expect(parsed.major_witnesses.length).toBeGreaterThan(0);
-  });
+      expect(Array.isArray(parsed.results)).toBe(true);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(Array.isArray(parsed.major_witnesses)).toBe(true);
+      expect(parsed.major_witnesses.length).toBeGreaterThan(0);
+    },
+  );
 
   test('topical_search("faith") returns results', { timeout: 30_000 }, async () => {
     const data = await callTool('topical_search', { topic: 'faith' });
@@ -104,47 +106,55 @@ describe.skipIf(!hasCredentials)('Integration: topical_search', () => {
     expect(parsed.results.length).toBeGreaterThan(0);
   });
 
-  test('response contains expected structure: results and major_witnesses arrays', { timeout: 30_000 }, async () => {
-    const data = await callTool('topical_search', { topic: 'grace' });
-    const parsed = parseContent(data);
+  test(
+    'response contains expected structure: results and major_witnesses arrays',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('topical_search', { topic: 'grace' });
+      const parsed = parseContent(data);
 
-    // Verify top-level structure
-    expect(Array.isArray(parsed.results)).toBe(true);
-    expect(Array.isArray(parsed.major_witnesses)).toBe(true);
+      // Verify top-level structure
+      expect(Array.isArray(parsed.results)).toBe(true);
+      expect(Array.isArray(parsed.major_witnesses)).toBe(true);
 
-    // Verify verse result structure (citation is a nested object)
-    if (parsed.results.length > 0) {
-      const verse = parsed.results[0];
-      expect(verse).toHaveProperty('citation');
-      expect(verse.citation).toHaveProperty('book');
-      expect(verse.citation).toHaveProperty('chapter');
-      expect(verse.citation).toHaveProperty('verse');
-    }
+      // Verify verse result structure (citation is a nested object)
+      if (parsed.results.length > 0) {
+        const verse = parsed.results[0];
+        expect(verse).toHaveProperty('citation');
+        expect(verse.citation).toHaveProperty('book');
+        expect(verse.citation).toHaveProperty('chapter');
+        expect(verse.citation).toHaveProperty('verse');
+      }
 
-    // Verify major witness structure
-    if (parsed.major_witnesses.length > 0) {
-      const witness = parsed.major_witnesses[0];
-      expect(witness).toHaveProperty('book');
-      expect(witness).toHaveProperty('match_reason');
-    }
-  });
+      // Verify major witness structure
+      if (parsed.major_witnesses.length > 0) {
+        const witness = parsed.major_witnesses[0];
+        expect(witness).toHaveProperty('book');
+        expect(witness).toHaveProperty('match_reason');
+      }
+    },
+  );
 });
 
 describe.skipIf(!hasCredentials)('Integration: semantic_search', () => {
-  test('semantic_search("hope in suffering") returns results with scores', { timeout: 30_000 }, async () => {
-    const data = await callTool('semantic_search', {
-      query: 'hope in suffering',
-    });
-    const parsed = parseContent(data);
+  test(
+    'semantic_search("hope in suffering") returns results with scores',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('semantic_search', {
+        query: 'hope in suffering',
+      });
+      const parsed = parseContent(data);
 
-    expect(Array.isArray(parsed.results)).toBe(true);
-    expect(parsed.results.length).toBeGreaterThan(0);
+      expect(Array.isArray(parsed.results)).toBe(true);
+      expect(parsed.results.length).toBeGreaterThan(0);
 
-    // Each result should have a score from vector search
-    for (const result of parsed.results) {
-      expect(typeof result.score).toBe('number');
-    }
-  });
+      // Each result should have a score from vector search
+      for (const result of parsed.results) {
+        expect(typeof result.score).toBe('number');
+      }
+    },
+  );
 
   test('semantic_search("love your neighbor") returns results', { timeout: 30_000 }, async () => {
     const data = await callTool('semantic_search', {
@@ -156,21 +166,25 @@ describe.skipIf(!hasCredentials)('Integration: semantic_search', () => {
     expect(parsed.results.length).toBeGreaterThan(0);
   });
 
-  test('results contain citation objects with book, chapter, verse', { timeout: 30_000 }, async () => {
-    const data = await callTool('semantic_search', {
-      query: 'the Lord is my shepherd',
-    });
-    const parsed = parseContent(data);
+  test(
+    'results contain citation objects with book, chapter, verse',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('semantic_search', {
+        query: 'the Lord is my shepherd',
+      });
+      const parsed = parseContent(data);
 
-    expect(parsed.results.length).toBeGreaterThan(0);
-    for (const result of parsed.results) {
-      // Grouped results have citation as a nested object
-      expect(result.citation).toBeDefined();
-      expect(typeof result.citation.book).toBe('string');
-      expect(typeof result.citation.chapter).toBe('number');
-      expect(typeof result.citation.verse).toBe('number');
-    }
-  });
+      expect(parsed.results.length).toBeGreaterThan(0);
+      for (const result of parsed.results) {
+        // Grouped results have citation as a nested object
+        expect(result.citation).toBeDefined();
+        expect(typeof result.citation.book).toBe('string');
+        expect(typeof result.citation.chapter).toBe('number');
+        expect(typeof result.citation.verse).toBe('number');
+      }
+    },
+  );
 
   test('results contain translations array', { timeout: 30_000 }, async () => {
     const data = await callTool('semantic_search', { query: 'forgiveness' });
@@ -185,14 +199,18 @@ describe.skipIf(!hasCredentials)('Integration: semantic_search', () => {
 });
 
 describe.skipIf(!hasCredentials)('Integration: find_text', () => {
-  test('find_text("faith hope") returns results (multi-word AND query)', { timeout: 30_000 }, async () => {
-    const data = await callTool('find_text', { query: 'faith hope' });
-    const parsed = parseContent(data);
+  test(
+    'find_text("faith hope") returns results (multi-word AND query)',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('find_text', { query: 'faith hope' });
+      const parsed = parseContent(data);
 
-    expect(Array.isArray(parsed.verses)).toBe(true);
-    expect(parsed.verses.length).toBeGreaterThan(0);
-    expect(parsed.count).toBeGreaterThan(0);
-  });
+      expect(Array.isArray(parsed.verses)).toBe(true);
+      expect(parsed.verses.length).toBeGreaterThan(0);
+      expect(parsed.count).toBeGreaterThan(0);
+    },
+  );
 
   test('find_text("suffer", translation="WEB") returns results', { timeout: 30_000 }, async () => {
     const data = await callTool('find_text', {
@@ -206,62 +224,74 @@ describe.skipIf(!hasCredentials)('Integration: find_text', () => {
     expect(parsed.count).toBeGreaterThan(0);
   });
 
-  test('find_text("God so loved") returns results (exact phrase preserved)', { timeout: 30_000 }, async () => {
-    const data = await callTool('find_text', {
-      query: '"God so loved"',
-    });
-    const parsed = parseContent(data);
+  test(
+    'find_text("God so loved") returns results (exact phrase preserved)',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('find_text', {
+        query: '"God so loved"',
+      });
+      const parsed = parseContent(data);
 
-    expect(Array.isArray(parsed.verses)).toBe(true);
-    expect(parsed.verses.length).toBeGreaterThan(0);
-    expect(parsed.count).toBeGreaterThan(0);
-  });
+      expect(Array.isArray(parsed.verses)).toBe(true);
+      expect(parsed.verses.length).toBeGreaterThan(0);
+      expect(parsed.count).toBeGreaterThan(0);
+    },
+  );
 
-  test('find_text("the") returns empty result with message (stop word stripped)', { timeout: 30_000 }, async () => {
-    const data = await callTool('find_text', { query: 'the' });
-    const parsed = parseContent(data);
+  test(
+    'find_text("the") returns empty result with message (stop word stripped)',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('find_text', { query: 'the' });
+      const parsed = parseContent(data);
 
-    // "the" is a stop word — sanitizeFts5 strips it, leaving no searchable terms
-    expect(parsed.count).toBe(0);
-    expect(Array.isArray(parsed.verses)).toBe(true);
-    expect(parsed.verses.length).toBe(0);
-    expect(parsed.message).toBe('No searchable terms found — try more specific keywords.');
-  });
+      // "the" is a stop word — sanitizeFts5 strips it, leaving no searchable terms
+      expect(parsed.count).toBe(0);
+      expect(Array.isArray(parsed.verses)).toBe(true);
+      expect(parsed.verses.length).toBe(0);
+      expect(parsed.message).toBe('No searchable terms found — try more specific keywords.');
+    },
+  );
 });
 
 describe.skipIf(!hasCredentials)('Integration: compare_translations', () => {
-  test('compare_translations(Psalms 34:18) returns all 5 translations', { timeout: 30_000 }, async () => {
-    const data = await callTool('compare_translations', {
-      book: 'Psalms',
-      chapter: 34,
-      verse_start: 18,
-    });
-    const parsed = parseContent(data);
+  test(
+    'compare_translations(Psalms 34:18) returns all 5 translations',
+    { timeout: 30_000 },
+    async () => {
+      const data = await callTool('compare_translations', {
+        book: 'Psalms',
+        chapter: 34,
+        verse_start: 18,
+      });
+      const parsed = parseContent(data);
 
-    // Response shape: { book, chapter, verse_start, verse_end, verses: [{ verse, translations: [{ text, citation }] }] }
-    expect(parsed.book).toBe('Psalms');
-    expect(parsed.chapter).toBe(34);
-    expect(parsed.verse_start).toBe(18);
-    expect(Array.isArray(parsed.verses)).toBe(true);
-    expect(parsed.verses.length).toBeGreaterThan(0);
+      // Response shape: { book, chapter, verse_start, verse_end, verses: [{ verse, translations: [{ text, citation }] }] }
+      expect(parsed.book).toBe('Psalms');
+      expect(parsed.chapter).toBe(34);
+      expect(parsed.verse_start).toBe(18);
+      expect(Array.isArray(parsed.verses)).toBe(true);
+      expect(parsed.verses.length).toBeGreaterThan(0);
 
-    // Each verse entry should have translations from all 5 translations
-    const firstVerse = parsed.verses[0];
-    expect(firstVerse.verse).toBe(18);
-    expect(Array.isArray(firstVerse.translations)).toBe(true);
+      // Each verse entry should have translations from all 5 translations
+      const firstVerse = parsed.verses[0];
+      expect(firstVerse.verse).toBe(18);
+      expect(Array.isArray(firstVerse.translations)).toBe(true);
 
-    // Collect all translation abbreviations from the first verse's translations
-    const translations = new Set<string>();
-    for (const entry of firstVerse.translations) {
-      expect(typeof entry.text).toBe('string');
-      expect(entry.citation).toBeDefined();
-      translations.add(entry.citation.translation);
-    }
+      // Collect all translation abbreviations from the first verse's translations
+      const translations = new Set<string>();
+      for (const entry of firstVerse.translations) {
+        expect(typeof entry.text).toBe('string');
+        expect(entry.citation).toBeDefined();
+        translations.add(entry.citation.translation);
+      }
 
-    // Should have all 5 translations
-    const expected = ['KJV', 'WEB', 'ASV', 'YLT', 'DBY'];
-    for (const t of expected) {
-      expect(translations.has(t)).toBe(true);
-    }
-  });
+      // Should have all 5 translations
+      const expected = ['KJV', 'WEB', 'ASV', 'YLT', 'DBY'];
+      for (const t of expected) {
+        expect(translations.has(t)).toBe(true);
+      }
+    },
+  );
 });

--- a/src/lib/bible-utils.ts
+++ b/src/lib/bible-utils.ts
@@ -39,9 +39,7 @@ const bookCache = new Map<string, Book>();
 // ─── Translations cache ───────────────────────────────────────────────────────
 
 async function loadTranslations(): Promise<void> {
-  const result = await d1.query(
-    'SELECT id, abbreviation, name, year FROM translations'
-  );
+  const result = await d1.query('SELECT id, abbreviation, name, year FROM translations');
 
   for (const row of result.results) {
     const t: Translation = {
@@ -74,7 +72,7 @@ export function isValidTranslation(abbrev: string): boolean {
 async function loadBooks(): Promise<void> {
   // Load canonical book names first.
   const booksResult = await d1.query(
-    'SELECT id, abbreviation, name, testament, canonical_order FROM books'
+    'SELECT id, abbreviation, name, testament, canonical_order FROM books',
   );
 
   const booksById = new Map<number, Book>();
@@ -94,9 +92,7 @@ async function loadBooks(): Promise<void> {
   }
 
   // Load aliases and index them.
-  const aliasResult = await d1.query(
-    'SELECT alias, book_id FROM book_aliases'
-  );
+  const aliasResult = await d1.query('SELECT alias, book_id FROM book_aliases');
 
   for (const row of aliasResult.results) {
     const bookId = row['book_id'] as number;
@@ -118,7 +114,7 @@ export function makeCitation(
   book: Book,
   chapter: number,
   verse: number,
-  translationAbbrev: string
+  translationAbbrev: string,
 ): Citation {
   return {
     book: book.name,
@@ -131,7 +127,7 @@ export function makeCitation(
 export function validateVerseRef(
   bookName: string,
   chapter: number,
-  verse: number
+  verse: number,
 ): { book: Book } | { error: string } {
   const book = resolveBook(bookName);
 
@@ -153,16 +149,14 @@ export function validateVerseRef(
 // ─── Initialization ───────────────────────────────────────────────────────────
 
 export async function init(): Promise<void> {
-  const apiToken =
-    process.env.BIBLE_API_TOKEN ?? process.env.CLOUDFLARE_API_TOKEN;
-  const accountId =
-    process.env.BIBLE_ACCOUNT_ID ?? process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.BIBLE_API_TOKEN ?? process.env.CLOUDFLARE_API_TOKEN;
+  const accountId = process.env.BIBLE_ACCOUNT_ID ?? process.env.CLOUDFLARE_ACCOUNT_ID;
   const databaseId = process.env.D1_DATABASE_ID;
 
   if (!apiToken || !accountId || !databaseId) {
     console.warn(
       '[bible-utils] D1 env vars not set (BIBLE_API_TOKEN or CLOUDFLARE_API_TOKEN, BIBLE_ACCOUNT_ID or CLOUDFLARE_ACCOUNT_ID, D1_DATABASE_ID). ' +
-        'Skipping cache pre-population. Bible lookups will fail at runtime.'
+        'Skipping cache pre-population. Bible lookups will fail at runtime.',
     );
     return;
   }
@@ -170,7 +164,7 @@ export async function init(): Promise<void> {
   await Promise.all([loadTranslations(), loadBooks()]);
 
   console.log(
-    `[bible-utils] Cache ready: ${translationCache.size} translations, ${bookCache.size} book entries`
+    `[bible-utils] Cache ready: ${translationCache.size} translations, ${bookCache.size} book entries`,
   );
 }
 

--- a/src/lib/cloudflare-etl.ts
+++ b/src/lib/cloudflare-etl.ts
@@ -29,7 +29,7 @@ export function sqlLiteral(value: unknown): string {
   }
   if (typeof value === 'object') {
     throw new TypeError(
-      `sqlLiteral does not accept objects; got ${Object.prototype.toString.call(value)}`
+      `sqlLiteral does not accept objects; got ${Object.prototype.toString.call(value)}`,
     );
   }
   // string (and fallback for anything else)
@@ -49,14 +49,12 @@ const ROWS_PER_INSERT = 200;
 export function buildMultiRowInserts(
   prefix: string,
   rows: unknown[][],
-  rowsPerInsert: number = ROWS_PER_INSERT
+  rowsPerInsert: number = ROWS_PER_INSERT,
 ): string {
   const lines: string[] = [];
   for (let start = 0; start < rows.length; start += rowsPerInsert) {
     const chunk = rows.slice(start, start + rowsPerInsert);
-    const tuples = chunk
-      .map((row) => `(${row.map(sqlLiteral).join(', ')})`)
-      .join(', ');
+    const tuples = chunk.map((row) => `(${row.map(sqlLiteral).join(', ')})`).join(', ');
     lines.push(`${prefix} ${tuples};`);
   }
   return lines.join('\n') + '\n';
@@ -69,15 +67,13 @@ export function inlineParams(sql: string, params: unknown[]): string {
   let paramIndex = 0;
   const result = sql.replace(/\?/g, () => {
     if (paramIndex >= params.length) {
-      throw new Error(
-        `SQL has more '?' placeholders than params: ${sql}`
-      );
+      throw new Error(`SQL has more '?' placeholders than params: ${sql}`);
     }
     return sqlLiteral(params[paramIndex++]);
   });
   if (paramIndex < params.length) {
     console.warn(
-      `[cloudflare-etl] inlineParams: ${params.length - paramIndex} extra param(s) unused for SQL: ${sql}`
+      `[cloudflare-etl] inlineParams: ${params.length - paramIndex} extra param(s) unused for SQL: ${sql}`,
     );
   }
   return result;
@@ -95,9 +91,7 @@ export function inlineParams(sql: string, params: unknown[]): string {
  * All other statement shapes are emitted as-is with params inlined
  * by positional substitution of '?' placeholders.
  */
-export function buildSqlFile(
-  statements: Array<{ sql: string; params?: unknown[] }>
-): string {
+export function buildSqlFile(statements: Array<{ sql: string; params?: unknown[] }>): string {
   // Split into INSERT groups vs other statements
   // We detect INSERT statements by looking for VALUES keyword so we can
   // group multiple rows into a single multi-value INSERT.
@@ -130,8 +124,7 @@ export function buildSqlFile(
         const nextValuesIdx = nextUpper.indexOf('VALUES');
         if (
           nextValuesIdx !== -1 &&
-          next.sql.slice(0, nextValuesIdx + 'VALUES'.length).trimEnd() ===
-            prefix
+          next.sql.slice(0, nextValuesIdx + 'VALUES'.length).trimEnd() === prefix
         ) {
           run.push(next.params ?? []);
           i++;
@@ -143,9 +136,7 @@ export function buildSqlFile(
       // Emit in chunks of ROWS_PER_INSERT
       for (let start = 0; start < run.length; start += ROWS_PER_INSERT) {
         const chunk = run.slice(start, start + ROWS_PER_INSERT);
-        const tuples = chunk
-          .map((params) => `(${params.map(sqlLiteral).join(', ')})`)
-          .join(', ');
+        const tuples = chunk.map((params) => `(${params.map(sqlLiteral).join(', ')})`).join(', ');
         lines.push(`${prefix} ${tuples};`);
       }
     } else {
@@ -170,10 +161,9 @@ async function d1BatchFile(sql: string): Promise<void> {
   const tmpFile = join(tmpdir(), `d1-batch-${Date.now()}-${process.pid}.sql`);
   try {
     writeFileSync(tmpFile, sql, 'utf8');
-    execSync(
-      `npx wrangler d1 execute ${d1DatabaseName} --remote --file="${tmpFile}"`,
-      { stdio: 'inherit' }
-    );
+    execSync(`npx wrangler d1 execute ${d1DatabaseName} --remote --file="${tmpFile}"`, {
+      stdio: 'inherit',
+    });
   } finally {
     try {
       unlinkSync(tmpFile);
@@ -189,9 +179,7 @@ async function d1BatchFile(sql: string): Promise<void> {
  * are grouped into multi-value INSERTs (up to 200 rows each).
  * No 100-statement limit — wrangler handles internal batching.
  */
-async function d1Batch(
-  statements: Array<{ sql: string; params?: unknown[] }>
-): Promise<void> {
+async function d1Batch(statements: Array<{ sql: string; params?: unknown[] }>): Promise<void> {
   if (statements.length === 0) return;
 
   const sql = buildSqlFile(statements);

--- a/src/lib/cloudflare.test.ts
+++ b/src/lib/cloudflare.test.ts
@@ -143,7 +143,7 @@ describe('d1.query()', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(d1.query('SELECT 1')).rejects.toThrow(
-      /D1 query returned an unexpected empty result array/
+      /D1 query returned an unexpected empty result array/,
     );
   });
 
@@ -156,9 +156,7 @@ describe('d1.query()', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(d1.query('SELECT 1')).rejects.toThrow(
-      /Cloudflare API error: 403 Forbidden/
-    );
+    await expect(d1.query('SELECT 1')).rejects.toThrow(/Cloudflare API error: 403 Forbidden/);
   });
 
   test('multiple concurrent queries via Promise.all return independent results', async () => {
@@ -180,10 +178,7 @@ describe('d1.query()', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    const [r1, r2] = await Promise.all([
-      d1.query('SELECT 1'),
-      d1.query('SELECT 2'),
-    ]);
+    const [r1, r2] = await Promise.all([d1.query('SELECT 1'), d1.query('SELECT 2')]);
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(r1.results).toEqual([{ id: 1 }]);

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -20,16 +20,12 @@ let _config: {
 export function getConfig() {
   if (!_config) {
     _config = {
-      apiToken:
-        process.env.BIBLE_API_TOKEN ?? process.env.CLOUDFLARE_API_TOKEN ?? '',
-      accountId:
-        process.env.BIBLE_ACCOUNT_ID ?? process.env.CLOUDFLARE_ACCOUNT_ID ?? '',
+      apiToken: process.env.BIBLE_API_TOKEN ?? process.env.CLOUDFLARE_API_TOKEN ?? '',
+      accountId: process.env.BIBLE_ACCOUNT_ID ?? process.env.CLOUDFLARE_ACCOUNT_ID ?? '',
       databaseId: process.env.D1_DATABASE_ID ?? '',
       indexName: process.env.VECTORIZE_INDEX_NAME ?? '',
       topicIndexName:
-        process.env.BIBLE_TOPIC_INDEX_NAME ??
-        process.env.VECTORIZE_TOPIC_INDEX_NAME ??
-        '',
+        process.env.BIBLE_TOPIC_INDEX_NAME ?? process.env.VECTORIZE_TOPIC_INDEX_NAME ?? '',
     };
   }
   return _config;
@@ -109,10 +105,7 @@ async function cfFetch<T>(url: string, init: RequestInit): Promise<T> {
 
 // ─── D1 client ────────────────────────────────────────────────────────────────
 
-async function d1Query(
-  sql: string,
-  params: unknown[] = []
-): Promise<D1Result> {
+async function d1Query(sql: string, params: unknown[] = []): Promise<D1Result> {
   const { accountId, databaseId } = getConfig();
   const d1Base = `${BASE}/accounts/${accountId}/d1/database/${databaseId}`;
   const result = await cfFetch<D1ResultSet[]>(`${d1Base}/query`, {
@@ -136,7 +129,7 @@ export const d1 = {
 
 async function vectorizeQuery(
   vector: number[],
-  options?: { topK?: number; filter?: Record<string, string | number> }
+  options?: { topK?: number; filter?: Record<string, string | number> },
 ): Promise<VectorizeMatch[]> {
   const { accountId, indexName } = getConfig();
   const vectorizeBase = `${BASE}/accounts/${accountId}/vectorize/v2/indexes/${indexName}`;
@@ -144,10 +137,10 @@ async function vectorizeQuery(
   if (options?.topK !== undefined) body['top_k'] = Math.min(options.topK, 20);
   if (options?.filter !== undefined) body['filter'] = options.filter;
 
-  const result = await cfFetch<{ matches: VectorizeMatch[] }>(
-    `${vectorizeBase}/query`,
-    { method: 'POST', body: JSON.stringify(body) }
-  );
+  const result = await cfFetch<{ matches: VectorizeMatch[] }>(`${vectorizeBase}/query`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
 
   return result.matches;
 }
@@ -157,13 +150,11 @@ async function vectorizeUpsert(
     id: string;
     values: number[];
     metadata?: Record<string, unknown>;
-  }>
+  }>,
 ): Promise<void> {
   if (vectors.length === 0) return;
   if (vectors.length > 1000) {
-    throw new Error(
-      `Vectorize upsert accepts at most 1000 vectors; received ${vectors.length}`
-    );
+    throw new Error(`Vectorize upsert accepts at most 1000 vectors; received ${vectors.length}`);
   }
 
   const { accountId, indexName } = getConfig();
@@ -197,7 +188,7 @@ export const vectorize = {
 
 async function vectorizeTopicsQuery(
   vector: number[],
-  options?: { topK?: number; filter?: Record<string, string | number> }
+  options?: { topK?: number; filter?: Record<string, string | number> },
 ): Promise<VectorizeMatch[]> {
   const { accountId, topicIndexName } = getConfig();
   if (!topicIndexName) return [];
@@ -207,10 +198,10 @@ async function vectorizeTopicsQuery(
   if (options?.topK !== undefined) body['top_k'] = Math.min(options.topK, 20);
   if (options?.filter !== undefined) body['filter'] = options.filter;
 
-  const result = await cfFetch<{ matches: VectorizeMatch[] }>(
-    `${vectorizeBase}/query`,
-    { method: 'POST', body: JSON.stringify(body) }
-  );
+  const result = await cfFetch<{ matches: VectorizeMatch[] }>(`${vectorizeBase}/query`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
 
   return result.matches;
 }
@@ -225,12 +216,12 @@ const DEFAULT_EMBED_MODEL = '@cf/baai/bge-base-en-v1.5';
 
 async function workersAiEmbed(
   texts: string[],
-  model: string = DEFAULT_EMBED_MODEL
+  model: string = DEFAULT_EMBED_MODEL,
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
   if (texts.length > 100) {
     throw new Error(
-      `Workers AI embed accepts at most 100 texts per request; received ${texts.length}`
+      `Workers AI embed accepts at most 100 texts per request; received ${texts.length}`,
     );
   }
 
@@ -240,7 +231,7 @@ async function workersAiEmbed(
     {
       method: 'POST',
       body: JSON.stringify({ text: texts }),
-    }
+    },
   );
 
   return result.data;

--- a/src/resources/chapter.ts
+++ b/src/resources/chapter.ts
@@ -39,7 +39,11 @@ interface ErrorResult {
 const handler: ResourceHandler = async (params) => {
   await ensureInitialized();
 
-  const { translation: translationParam, book, chapter } = params as {
+  const {
+    translation: translationParam,
+    book,
+    chapter,
+  } = params as {
     translation: string;
     book: string;
     chapter: string;
@@ -86,7 +90,7 @@ const handler: ResourceHandler = async (params) => {
         AND v.book_id = ?
         AND v.chapter = ?
       ORDER BY v.verse`,
-    [translation.id, resolvedBook.id, chapterNum]
+    [translation.id, resolvedBook.id, chapterNum],
   );
 
   if (queryResult.results.length === 0) {

--- a/src/resources/chapter.ts
+++ b/src/resources/chapter.ts
@@ -4,7 +4,7 @@
 // per verse. Book names are resolved via the alias resolver so common
 // variants (Gen, gen, Genesis) all work.
 
-import type { ResourceHandler } from '@mctx-ai/app';
+import type { ResourceHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   getTranslation,
@@ -36,25 +36,22 @@ interface ErrorResult {
   error: string;
 }
 
-const handler: ResourceHandler = async (params) => {
+const handler: ResourceHandler = async (
+  _mctx: ModelContext,
+  req: Record<string, string>,
+  res: MctxResponse,
+) => {
   await ensureInitialized();
 
-  const {
-    translation: translationParam,
-    book,
-    chapter,
-  } = params as {
-    translation: string;
-    book: string;
-    chapter: string;
-  };
+  const { translation: translationParam, book, chapter } = req;
 
   const translationUpper = translationParam.toUpperCase();
   if (!isValidTranslation(translationUpper)) {
     const result: ErrorResult = {
       error: `Unknown translation: "${translationParam}". Use bible://translations to list available translations.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const resolvedBook = resolveBook(book);
@@ -62,7 +59,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Unknown book: "${book}". Check spelling or use a common abbreviation (e.g. Gen, Matt, Rev).`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const chapterNum = parseInt(chapter, 10);
@@ -70,7 +68,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Chapter must be a positive integer; got "${chapter}".`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const translation = getTranslation(translationUpper);
@@ -80,7 +79,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Translation "${translationUpper}" not found in cache. Try again after initialization.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const queryResult = await d1.query(
@@ -97,7 +97,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `No verses found for ${resolvedBook.name} chapter ${chapterNum} in ${translationUpper}. The chapter may not exist in this translation.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const verses: VerseResult[] = (queryResult.results as unknown as VerseRow[]).map((row) => ({
@@ -112,7 +113,7 @@ const handler: ResourceHandler = async (params) => {
     verses,
   };
 
-  return JSON.stringify(result);
+  res.send(JSON.stringify(result));
 };
 
 handler.description =

--- a/src/resources/translations.ts
+++ b/src/resources/translations.ts
@@ -4,13 +4,17 @@
 // full name, and year. Data is served from the in-memory cache populated at
 // module load time — no D1 round-trip per request.
 
-import type { ResourceHandler } from '@mctx-ai/app';
+import type { ResourceHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
 import { getAllTranslations, ensureInitialized } from '../lib/bible-utils.js';
 
-const handler: ResourceHandler = async (_params) => {
+const handler: ResourceHandler = async (
+  _mctx: ModelContext,
+  _req: Record<string, string>,
+  res: MctxResponse,
+) => {
   await ensureInitialized();
   const translations = getAllTranslations();
-  return JSON.stringify(translations);
+  res.send(JSON.stringify(translations));
 };
 
 handler.description =

--- a/src/resources/verse.ts
+++ b/src/resources/verse.ts
@@ -4,7 +4,7 @@
 // requested verse is marked with `requested: true` so callers can identify
 // it within the context window. All verses carry structured Citation objects.
 
-import type { ResourceHandler } from '@mctx-ai/app';
+import type { ResourceHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   getTranslation,
@@ -42,27 +42,22 @@ interface ErrorResult {
   error: string;
 }
 
-const handler: ResourceHandler = async (params) => {
+const handler: ResourceHandler = async (
+  _mctx: ModelContext,
+  req: Record<string, string>,
+  res: MctxResponse,
+) => {
   await ensureInitialized();
 
-  const {
-    translation: translationParam,
-    book,
-    chapter,
-    verse,
-  } = params as {
-    translation: string;
-    book: string;
-    chapter: string;
-    verse: string;
-  };
+  const { translation: translationParam, book, chapter, verse } = req;
 
   const translationUpper = translationParam.toUpperCase();
   if (!isValidTranslation(translationUpper)) {
     const result: ErrorResult = {
       error: `Unknown translation: "${translationParam}". Use bible://translations to list available translations.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const resolvedBook = resolveBook(book);
@@ -70,7 +65,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Unknown book: "${book}". Check spelling or use a common abbreviation (e.g. Gen, Matt, Rev).`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const chapterNum = parseInt(chapter, 10);
@@ -78,7 +74,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Chapter must be a positive integer; got "${chapter}".`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const verseNum = parseInt(verse, 10);
@@ -86,7 +83,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Verse must be a positive integer; got "${verse}".`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const translation = getTranslation(translationUpper);
@@ -96,7 +94,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Translation "${translationUpper}" not found in cache. Try again after initialization.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const minVerse = Math.max(1, verseNum - CONTEXT_BEFORE);
@@ -118,7 +117,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `No verses found near ${resolvedBook.name} ${chapterNum}:${verseNum} in ${translationUpper}. Verify the reference exists.`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   // Check the requested verse is actually present in the result set.
@@ -128,7 +128,8 @@ const handler: ResourceHandler = async (params) => {
     const result: ErrorResult = {
       error: `Verse ${verseNum} does not exist in ${resolvedBook.name} chapter ${chapterNum} (${translationUpper}).`,
     };
-    return JSON.stringify(result);
+    res.send(JSON.stringify(result));
+    return;
   }
 
   const verses: VerseResult[] = rows.map((row) => {
@@ -150,7 +151,7 @@ const handler: ResourceHandler = async (params) => {
     verses,
   };
 
-  return JSON.stringify(result);
+  res.send(JSON.stringify(result));
 };
 
 handler.description =

--- a/src/resources/verse.ts
+++ b/src/resources/verse.ts
@@ -111,7 +111,7 @@ const handler: ResourceHandler = async (params) => {
         AND v.verse >= ?
         AND v.verse <= ?
       ORDER BY v.verse`,
-    [translation.id, resolvedBook.id, chapterNum, minVerse, maxVerse]
+    [translation.id, resolvedBook.id, chapterNum, minVerse, maxVerse],
   );
 
   if (queryResult.results.length === 0) {

--- a/src/tools/compare-translations.ts
+++ b/src/tools/compare-translations.ts
@@ -3,8 +3,8 @@
 // Returns the same passage from all 5 translations side-by-side.
 // Each verse is fully cited with a structured Citation object.
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   resolveBook,
@@ -36,7 +36,7 @@ interface CompareTranslationsResult {
 
 // ─── Handler ──────────────────────────────────────────────────────────────────
 
-const compareTranslations: ToolHandler = async (args, _ask?) => {
+const compareTranslations: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
   const {
@@ -44,7 +44,7 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
     chapter,
     verse_start,
     verse_end,
-  } = args as {
+  } = req as {
     book: string;
     chapter: number;
     verse_start: number;
@@ -122,7 +122,7 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
     verses,
   };
 
-  return response;
+  res.send(response);
 };
 
 compareTranslations.annotations = {

--- a/src/tools/compare-translations.ts
+++ b/src/tools/compare-translations.ts
@@ -39,7 +39,12 @@ interface CompareTranslationsResult {
 const compareTranslations: ToolHandler = async (args, _ask?) => {
   await ensureInitialized();
 
-  const { book: bookInput, chapter, verse_start, verse_end } = args as {
+  const {
+    book: bookInput,
+    chapter,
+    verse_start,
+    verse_end,
+  } = args as {
     book: string;
     chapter: number;
     verse_start: number;
@@ -62,9 +67,7 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
     throw new Error(`verse_start must be a positive integer; got ${verse_start}`);
   }
   if (!Number.isInteger(resolvedVerseEnd) || resolvedVerseEnd < verse_start) {
-    throw new Error(
-      `verse_end must be >= verse_start (${verse_start}); got ${resolvedVerseEnd}`
-    );
+    throw new Error(`verse_end must be >= verse_start (${verse_start}); got ${resolvedVerseEnd}`);
   }
 
   const translations = getAllTranslations();
@@ -83,7 +86,7 @@ const compareTranslations: ToolHandler = async (args, _ask?) => {
        AND v.verse >= ?
        AND v.verse <= ?
      ORDER BY v.verse ASC, t.abbreviation ASC`,
-    [book.id, chapter, verse_start, resolvedVerseEnd]
+    [book.id, chapter, verse_start, resolvedVerseEnd],
   );
 
   // Group rows by verse number
@@ -131,7 +134,7 @@ compareTranslations.annotations = {
 
 compareTranslations.description =
   'Show a known Bible passage side-by-side across all 5 translations (KJV, WEB, ASV, YLT, DBY). Use when the relevant verse or passage has already been identified and the goal is to compare wording, nuance, or translation choices across renderings. ' +
-  'This helps interpret a passage; it does not discover the Bible\'s major teaching on a topic.';
+  "This helps interpret a passage; it does not discover the Bible's major teaching on a topic.";
 
 compareTranslations.input = {
   book: T.string({

--- a/src/tools/concordance.ts
+++ b/src/tools/concordance.ts
@@ -5,8 +5,8 @@
 // configurable result limit. When results are truncated a total_count field
 // is included so callers know there are more matches.
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   getTranslation,
@@ -41,14 +41,14 @@ interface ConcordanceResult {
 const CONCORDANCE_DEFAULT_LIMIT = 100;
 const CONCORDANCE_MAX_LIMIT = 500;
 
-const concordance: ToolHandler = async (args, _ask?) => {
+const concordance: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
   const {
     query,
     translation,
     limit: rawLimit,
-  } = args as {
+  } = req as {
     query: string;
     translation?: string;
     limit?: number;
@@ -76,7 +76,8 @@ const concordance: ToolHandler = async (args, _ask?) => {
       truncated: false,
       occurrences: [],
     };
-    return { ...response, message: 'No searchable terms found — try more specific keywords.' };
+    res.send({ ...response, message: 'No searchable terms found — try more specific keywords.' });
+    return;
   }
 
   // Fetch one extra row beyond the limit so we can detect truncation without
@@ -191,7 +192,7 @@ const concordance: ToolHandler = async (args, _ask?) => {
     response.total_count = countResult.results[0]['total'] as number;
   }
 
-  return response;
+  res.send(response);
 };
 
 concordance.annotations = {

--- a/src/tools/concordance.ts
+++ b/src/tools/concordance.ts
@@ -44,18 +44,25 @@ const CONCORDANCE_MAX_LIMIT = 500;
 const concordance: ToolHandler = async (args, _ask?) => {
   await ensureInitialized();
 
-  const { query, translation, limit: rawLimit } = args as {
+  const {
+    query,
+    translation,
+    limit: rawLimit,
+  } = args as {
     query: string;
     translation?: string;
     limit?: number;
   };
 
-  const limit = Math.max(1, Math.floor(Math.min(rawLimit ?? CONCORDANCE_DEFAULT_LIMIT, CONCORDANCE_MAX_LIMIT)));
+  const limit = Math.max(
+    1,
+    Math.floor(Math.min(rawLimit ?? CONCORDANCE_DEFAULT_LIMIT, CONCORDANCE_MAX_LIMIT)),
+  );
 
   // Validate translation filter if provided.
   if (translation !== undefined && !isValidTranslation(translation)) {
     throw new Error(
-      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`
+      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`,
     );
   }
 

--- a/src/tools/cross-references.ts
+++ b/src/tools/cross-references.ts
@@ -4,8 +4,8 @@
 // Each result includes the referenced verse text (KJV) and structured Citations
 // for both the source verse and the referenced verse.
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   resolveBook,
@@ -38,7 +38,7 @@ interface CrossReferencesResult {
 const DEFAULT_TRANSLATION = 'KJV';
 const DEFAULT_LIMIT = 20;
 
-const crossReferences: ToolHandler = async (args, _ask?) => {
+const crossReferences: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
   const {
@@ -46,7 +46,7 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
     chapter,
     verse,
     limit: rawLimit,
-  } = args as {
+  } = req as {
     book: string;
     chapter: number;
     verse: number;
@@ -151,7 +151,7 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
     total_returned: crossReferenceEntries.length,
   };
 
-  return response;
+  res.send(response);
 };
 
 crossReferences.annotations = {

--- a/src/tools/cross-references.ts
+++ b/src/tools/cross-references.ts
@@ -41,7 +41,12 @@ const DEFAULT_LIMIT = 20;
 const crossReferences: ToolHandler = async (args, _ask?) => {
   await ensureInitialized();
 
-  const { book: bookInput, chapter, verse, limit: rawLimit } = args as {
+  const {
+    book: bookInput,
+    chapter,
+    verse,
+    limit: rawLimit,
+  } = args as {
     book: string;
     chapter: number;
     verse: number;
@@ -76,7 +81,7 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
       `SELECT text FROM verses
             WHERE book_id = ? AND chapter = ? AND verse = ? AND translation_id = ?
             LIMIT 1`,
-      [book.id, chapter, verse, translation.id]
+      [book.id, chapter, verse, translation.id],
     ),
     d1.query(
       `SELECT
@@ -98,46 +103,44 @@ const crossReferences: ToolHandler = async (args, _ask?) => {
                AND cr.from_verse    = ?
              ORDER BY cr.confidence DESC NULLS LAST, cr.id ASC
              LIMIT ?`,
-      [translation.id, book.id, chapter, verse, limit]
+      [translation.id, book.id, chapter, verse, limit],
     ),
   ]);
 
   if (sourceResult.results.length === 0) {
     throw new Error(
       `Verse not found: ${book.name} ${chapter}:${verse} (${DEFAULT_TRANSLATION}). ` +
-        'The verse may not exist in the database or the reference is out of range.'
+        'The verse may not exist in the database or the reference is out of range.',
     );
   }
 
   const sourceText = sourceResult.results[0]['text'] as string;
   const sourceCitation = makeCitation(book, chapter, verse, DEFAULT_TRANSLATION);
 
-  const crossReferenceEntries: CrossReferenceEntry[] = xrefResult.results.map(
-    (row) => {
-      const toBookName = row['to_book_name'] as string;
-      const toChapter = row['to_chapter'] as number;
-      const toVerse = row['to_verse'] as number;
-      const toText = (row['to_text'] as string | null) ?? '[verse text not available]';
-      const confidence = row['confidence'] as number | null;
+  const crossReferenceEntries: CrossReferenceEntry[] = xrefResult.results.map((row) => {
+    const toBookName = row['to_book_name'] as string;
+    const toChapter = row['to_chapter'] as number;
+    const toVerse = row['to_verse'] as number;
+    const toText = (row['to_text'] as string | null) ?? '[verse text not available]';
+    const confidence = row['confidence'] as number | null;
 
-      // Resolve target book for makeCitation (needs Book object)
-      const toBook = resolveBook(toBookName);
-      const toCitation: Citation = toBook
-        ? makeCitation(toBook, toChapter, toVerse, DEFAULT_TRANSLATION)
-        : {
-            book: toBookName,
-            chapter: toChapter,
-            verse: toVerse,
-            translation: DEFAULT_TRANSLATION,
-          };
+    // Resolve target book for makeCitation (needs Book object)
+    const toBook = resolveBook(toBookName);
+    const toCitation: Citation = toBook
+      ? makeCitation(toBook, toChapter, toVerse, DEFAULT_TRANSLATION)
+      : {
+          book: toBookName,
+          chapter: toChapter,
+          verse: toVerse,
+          translation: DEFAULT_TRANSLATION,
+        };
 
-      return {
-        text: toText,
-        citation: toCitation,
-        confidence,
-      };
-    }
-  );
+    return {
+      text: toText,
+      citation: toCitation,
+      confidence,
+    };
+  });
 
   const response: CrossReferencesResult = {
     source: {

--- a/src/tools/find-text.ts
+++ b/src/tools/find-text.ts
@@ -5,8 +5,8 @@
 // User-supplied double-quoted phrases are preserved as exact phrase matches.
 // FTS5 metacharacters are stripped from all unquoted words.
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   getTranslation,
@@ -147,14 +147,14 @@ interface FindTextResult {
 const FIND_TEXT_DEFAULT_LIMIT = 20;
 const FIND_TEXT_MAX_LIMIT = 100;
 
-const findText: ToolHandler = async (args, _ask?) => {
+const findText: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
   const {
     query,
     translation,
     limit: rawLimit,
-  } = args as {
+  } = req as {
     query: string;
     translation?: string;
     limit?: number;
@@ -182,7 +182,8 @@ const findText: ToolHandler = async (args, _ask?) => {
       count: 0,
       verses: [],
     };
-    return { ...response, message: 'No searchable terms found — try more specific keywords.' };
+    res.send({ ...response, message: 'No searchable terms found — try more specific keywords.' });
+    return;
   }
 
   let sql: string;
@@ -248,7 +249,7 @@ const findText: ToolHandler = async (args, _ask?) => {
     verses,
   };
 
-  return response;
+  res.send(response);
 };
 
 findText.annotations = {

--- a/src/tools/find-text.ts
+++ b/src/tools/find-text.ts
@@ -21,10 +21,47 @@ import type { Citation } from '../lib/bible-utils.js';
 
 /** Common English stop words stripped from multi-word queries. */
 const STOP_WORDS = new Set([
-  'a', 'an', 'the', 'in', 'of', 'for', 'to', 'is', 'it', 'and', 'or',
-  'but', 'with', 'by', 'at', 'on', 'from', 'as', 'be', 'was', 'were',
-  'been', 'are', 'am', 'do', 'does', 'did', 'has', 'have', 'had', 'this',
-  'that', 'these', 'those', 'so', 'if', 'not', 'no', 'up', 'out', 'its',
+  'a',
+  'an',
+  'the',
+  'in',
+  'of',
+  'for',
+  'to',
+  'is',
+  'it',
+  'and',
+  'or',
+  'but',
+  'with',
+  'by',
+  'at',
+  'on',
+  'from',
+  'as',
+  'be',
+  'was',
+  'were',
+  'been',
+  'are',
+  'am',
+  'do',
+  'does',
+  'did',
+  'has',
+  'have',
+  'had',
+  'this',
+  'that',
+  'these',
+  'those',
+  'so',
+  'if',
+  'not',
+  'no',
+  'up',
+  'out',
+  'its',
 ]);
 
 /** Strip FTS5 metacharacters from an individual word. */
@@ -113,18 +150,25 @@ const FIND_TEXT_MAX_LIMIT = 100;
 const findText: ToolHandler = async (args, _ask?) => {
   await ensureInitialized();
 
-  const { query, translation, limit: rawLimit } = args as {
+  const {
+    query,
+    translation,
+    limit: rawLimit,
+  } = args as {
     query: string;
     translation?: string;
     limit?: number;
   };
 
-  const limit = Math.max(1, Math.floor(Math.min(rawLimit ?? FIND_TEXT_DEFAULT_LIMIT, FIND_TEXT_MAX_LIMIT)));
+  const limit = Math.max(
+    1,
+    Math.floor(Math.min(rawLimit ?? FIND_TEXT_DEFAULT_LIMIT, FIND_TEXT_MAX_LIMIT)),
+  );
 
   // Validate translation filter if provided.
   if (translation !== undefined && !isValidTranslation(translation)) {
     throw new Error(
-      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`
+      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`,
     );
   }
 

--- a/src/tools/search-bible.ts
+++ b/src/tools/search-bible.ts
@@ -71,7 +71,7 @@ const LOCATION_CHUNK_SIZE = 30;
 
 function buildVectorizeFilter(
   bookId: number | undefined,
-  testament: string | undefined
+  testament: string | undefined,
 ): Record<string, string | number> | undefined {
   const filter: Record<string, string | number> = {};
 
@@ -125,7 +125,7 @@ interface D1VerseRow {
 
 async function fetchVersesByTranslation(
   locations: Array<{ book_id: number; chapter: number; verse: number }>,
-  translationId: number
+  translationId: number,
 ): Promise<D1VerseRow[]> {
   if (locations.length === 0) return [];
 
@@ -146,11 +146,7 @@ async function fetchVersesByTranslation(
         .map(() => '(v.book_id = ? AND v.chapter = ? AND v.verse = ?)')
         .join(' OR ');
 
-      const params: unknown[] = chunk.flatMap((loc) => [
-        loc.book_id,
-        loc.chapter,
-        loc.verse,
-      ]);
+      const params: unknown[] = chunk.flatMap((loc) => [loc.book_id, loc.chapter, loc.verse]);
       params.push(translationId);
 
       const sql = `
@@ -183,14 +179,14 @@ async function fetchVersesByTranslation(
       }));
 
       allRows.push(...rows);
-    })
+    }),
   );
 
   return allRows;
 }
 
 async function fetchVersesByLocations(
-  locations: Array<{ book_id: number; chapter: number; verse: number }>
+  locations: Array<{ book_id: number; chapter: number; verse: number }>,
 ): Promise<D1VerseRow[]> {
   if (locations.length === 0) return [];
 
@@ -209,11 +205,7 @@ async function fetchVersesByLocations(
         .map(() => '(v.book_id = ? AND v.chapter = ? AND v.verse = ?)')
         .join(' OR ');
 
-      const params: unknown[] = chunk.flatMap((loc) => [
-        loc.book_id,
-        loc.chapter,
-        loc.verse,
-      ]);
+      const params: unknown[] = chunk.flatMap((loc) => [loc.book_id, loc.chapter, loc.verse]);
 
       const sql = `
         SELECT
@@ -244,7 +236,7 @@ async function fetchVersesByLocations(
       }));
 
       allRows.push(...rows);
-    })
+    }),
   );
 
   return allRows;
@@ -270,10 +262,7 @@ const searchBible: ToolHandler = async (args, _ask?) => {
   };
 
   // Validate and clamp limit.
-  const limit = Math.min(
-    Math.max(1, Math.floor(limitRaw ?? DEFAULT_LIMIT)),
-    MAX_LIMIT
-  );
+  const limit = Math.min(Math.max(1, Math.floor(limitRaw ?? DEFAULT_LIMIT)), MAX_LIMIT);
 
   // Resolve optional book filter.
   let bookFilter: Book | undefined;
@@ -336,7 +325,7 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     // translation. This is more reliable than Vectorize metadata filtering, which can
     // silently drop candidates during ANN retrieval.
     const translationMatches = matches.filter(
-      (match) => match.metadata?.['translation_id'] === translationId
+      (match) => match.metadata?.['translation_id'] === translationId,
     );
 
     // Collect valid locations from the filtered vector matches.
@@ -374,15 +363,9 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     const rows = await fetchVersesByTranslation(locations, translationId);
 
     const results: VerseResult[] = rows.map((row) => {
-      const score =
-        scoreByLocation.get(`${row.book_id}:${row.chapter}:${row.verse}`) ?? 0;
+      const score = scoreByLocation.get(`${row.book_id}:${row.chapter}:${row.verse}`) ?? 0;
       const book = resolveBook(row.book_name) ?? ({ id: row.book_id, name: row.book_name } as Book);
-      const citation: Citation = makeCitation(
-        book,
-        row.chapter,
-        row.verse,
-        row.translation_abbrev
-      );
+      const citation: Citation = makeCitation(book, row.chapter, row.verse, row.translation_abbrev);
       return { citation, text: row.text, score };
     });
 

--- a/src/tools/search-bible.ts
+++ b/src/tools/search-bible.ts
@@ -5,8 +5,8 @@
 // verse locations and returns all translations for each location from D1.
 // When a translation filter is set, the limit applies directly to results.
 
-import { T } from '@mctx-ai/app';
-import type { ToolHandler } from '@mctx-ai/app';
+import { T } from '@mctx-ai/mcp';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
 import { vectorize, workersAi, d1 } from '../lib/cloudflare.js';
 import {
   resolveBook,
@@ -244,7 +244,7 @@ async function fetchVersesByLocations(
 
 // ─── Tool implementation ──────────────────────────────────────────────────────
 
-const searchBible: ToolHandler = async (args, _ask?) => {
+const searchBible: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
   const {
@@ -253,7 +253,7 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     translation: translationArg,
     book: bookArg,
     testament: testamentArg,
-  } = args as {
+  } = req as {
     query: string;
     limit?: number;
     translation?: string;
@@ -315,8 +315,8 @@ const searchBible: ToolHandler = async (args, _ask?) => {
   const matches = await vectorize.query(queryVector, { topK, filter });
 
   if (!matches || matches.length === 0) {
-    const result: SearchResult = { query, results: [], total: 0 };
-    return result;
+    res.send({ query, results: [], total: 0 } satisfies SearchResult);
+    return;
   }
 
   if (translationId) {
@@ -349,8 +349,8 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     }
 
     if (locations.length === 0) {
-      const result: SearchResult = { query, results: [], total: 0 };
-      return result;
+      res.send({ query, results: [], total: 0 } satisfies SearchResult);
+      return;
     }
 
     // Build a score map keyed by location for later annotation.
@@ -372,12 +372,8 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     // Sort by descending score (D1 returns in canonical order).
     results.sort((a, b) => b.score - a.score);
 
-    const output: SearchResult = {
-      query,
-      results,
-      total: results.length,
-    };
-    return output;
+    res.send({ query, results, total: results.length } satisfies SearchResult);
+    return;
   }
 
   // No translation filter path: deduplicate to unique verse locations,
@@ -411,8 +407,8 @@ const searchBible: ToolHandler = async (args, _ask?) => {
   }
 
   if (uniqueLocations.length === 0) {
-    const result: SearchResult = { query, results: [], total: 0 };
-    return result;
+    res.send({ query, results: [], total: 0 } satisfies SearchResult);
+    return;
   }
 
   // Fetch all translations for the unique locations.
@@ -453,12 +449,7 @@ const searchBible: ToolHandler = async (args, _ask?) => {
     .map((loc) => groupMap.get(`${loc.book_id}:${loc.chapter}:${loc.verse}`))
     .filter((g): g is GroupedVerseResult => g !== undefined);
 
-  const output: GroupedSearchResult = {
-    query,
-    results,
-    total: results.length,
-  };
-  return output;
+  res.send({ query, results, total: results.length } satisfies GroupedSearchResult);
 };
 
 searchBible.annotations = {

--- a/src/tools/topical-search.ts
+++ b/src/tools/topical-search.ts
@@ -77,7 +77,7 @@ const MAX_MAJOR_WITNESSES_NARRATIVE = 5;
 // direct topical relevance). The increase is intentionally moderate — raising
 // too high (e.g. 0.65) removes legitimate witnesses for queries like "end
 // times prophecy" where many books score similarly.
-const WITNESS_SCORE_CUTOFF = 0.60;
+const WITNESS_SCORE_CUTOFF = 0.6;
 // Narrative queries use a stricter cutoff — only genuinely related secondary
 // witnesses survive (e.g. Hebrews 11, 1 Peter 3 for Noah — not Exodus, Numbers).
 const WITNESS_SCORE_CUTOFF_NARRATIVE = 0.75;
@@ -300,9 +300,7 @@ function naveTopicRelevance(topicName: string, query: string): number {
 // Queries the Vectorize topics index once and splits results by ID prefix into
 // topic-level and book-level matches. Falls back to empty arrays if the topic
 // index is not configured.
-async function searchSemanticTopicsAndBooks(
-  queryVector: number[],
-): Promise<{
+async function searchSemanticTopicsAndBooks(queryVector: number[]): Promise<{
   topics: Array<{ id: number; name: string; score: number }>;
   books: Array<{ book_id: number; score: number }>;
 }> {
@@ -335,10 +333,7 @@ async function searchSemanticTopicsAndBooks(
 
 // Queries nave_topic_book_salience for matching topic+book combinations.
 // Returns a Map keyed by 'bookId:topicId' → salience score.
-async function fetchSalience(
-  topicIds: number[],
-  bookIds: number[],
-): Promise<Map<string, number>> {
+async function fetchSalience(topicIds: number[], bookIds: number[]): Promise<Map<string, number>> {
   if (topicIds.length === 0 || bookIds.length === 0) return new Map();
 
   const topicPlaceholders = topicIds.map(() => '?').join(', ');
@@ -372,10 +367,33 @@ async function queryExpandedTopicsByLike(
   // faithfulness during suffering" matches topics containing any of those
   // words. Skip short/common words to avoid overly broad matches.
   const stopWords = new Set([
-    'the', 'and', 'for', 'but', 'not', 'with', 'from', 'that', 'this',
-    'into', 'over', 'upon', 'also', 'than', 'then', 'them', 'they',
-    'have', 'been', 'were', 'will', 'does', 'done', 'during', 'about',
-    "god's", 'gods',
+    'the',
+    'and',
+    'for',
+    'but',
+    'not',
+    'with',
+    'from',
+    'that',
+    'this',
+    'into',
+    'over',
+    'upon',
+    'also',
+    'than',
+    'then',
+    'them',
+    'they',
+    'have',
+    'been',
+    'were',
+    'will',
+    'does',
+    'done',
+    'during',
+    'about',
+    "god's",
+    'gods',
   ]);
 
   const words = topic
@@ -493,9 +511,7 @@ async function expandTopicsByCooccurrence(
 
 const WITNESS_CHUNK_SIZE = 100;
 
-async function aggregateWitnesses(
-  topicIds: number[],
-): Promise<WitnessCandidate[]> {
+async function aggregateWitnesses(topicIds: number[]): Promise<WitnessCandidate[]> {
   if (topicIds.length === 0) return [];
 
   // Defensively chunk if topic IDs exceed 100 to stay within D1 parameter limits.
@@ -551,9 +567,7 @@ async function aggregateWitnesses(
         const maxChapter = row['max_chapter'] as number;
         const topicNamesStr = row['topic_names'] as string;
 
-        const topicNames = topicNamesStr
-          ? topicNamesStr.split(',').map((n) => n.trim())
-          : [];
+        const topicNames = topicNamesStr ? topicNamesStr.split(',').map((n) => n.trim()) : [];
 
         if (!bookAgg.has(bookId)) {
           bookAgg.set(bookId, {
@@ -658,10 +672,7 @@ function detectQueryNarrative(
 
 // ─── Narrative detection ──────────────────────────────────────────────────────
 
-function detectNarrative(
-  candidate: WitnessCandidate,
-  matchedTopics: string[],
-): string | undefined {
+function detectNarrative(candidate: WitnessCandidate, matchedTopics: string[]): string | undefined {
   const totalChapters = BOOK_TOTAL_CHAPTERS[candidate.book_name];
 
   for (const topic of matchedTopics) {
@@ -671,8 +682,7 @@ function detectNarrative(
 
     // If the candidate spans fewer chapters than the full book, it's a subset.
     const spannedChapters = candidate.max_chapter - candidate.min_chapter + 1;
-    const isSubset =
-      totalChapters !== undefined && spannedChapters < totalChapters * 0.8;
+    const isSubset = totalChapters !== undefined && spannedChapters < totalChapters * 0.8;
 
     if (isSubset) {
       // Title-case the topic name as the narrative label.
@@ -696,13 +706,19 @@ function buildWitnessMatchReason(
   themesMatched?: string[],
 ): string {
   const genre = BOOK_GENRE[candidate.book_name] ?? 'Unknown';
-  const topThemes = themesMatched && themesMatched.length > 0
-    ? themesMatched.slice(0, 3)
-    : candidate.topic_names.split(',').map((n) => n.trim()).filter(Boolean).slice(0, 3);
+  const topThemes =
+    themesMatched && themesMatched.length > 0
+      ? themesMatched.slice(0, 3)
+      : candidate.topic_names
+          .split(',')
+          .map((n) => n.trim())
+          .filter(Boolean)
+          .slice(0, 3);
 
-  const themePhrase = topThemes.length > 1
-    ? topThemes.slice(0, -1).join(', ') + ' and ' + topThemes[topThemes.length - 1]
-    : topThemes[0] ?? 'this theme';
+  const themePhrase =
+    topThemes.length > 1
+      ? topThemes.slice(0, -1).join(', ') + ' and ' + topThemes[topThemes.length - 1]
+      : (topThemes[0] ?? 'this theme');
 
   if (narrative) {
     // Narrative arc within a book — focus on the story rather than counts.
@@ -966,7 +982,8 @@ async function fetchRepresentativeVerse(
       (Math.abs(effectiveScore - bestAnyEffectiveScore) <= SCORE_TIE_BAND &&
         bestAnyVerseRow !== undefined &&
         (verseRow.chapter < bestAnyVerseRow.chapter ||
-          (verseRow.chapter === bestAnyVerseRow.chapter && verseRow.verse < bestAnyVerseRow.verse)));
+          (verseRow.chapter === bestAnyVerseRow.chapter &&
+            verseRow.verse < bestAnyVerseRow.verse)));
 
     if (isAnyBetter) {
       bestAnyEffectiveScore = effectiveScore;
@@ -980,7 +997,8 @@ async function fetchRepresentativeVerse(
         (Math.abs(effectiveScore - bestTopicEffectiveScore) <= SCORE_TIE_BAND &&
           bestTopicVerseRow !== undefined &&
           (verseRow.chapter < bestTopicVerseRow.chapter ||
-            (verseRow.chapter === bestTopicVerseRow.chapter && verseRow.verse < bestTopicVerseRow.verse)));
+            (verseRow.chapter === bestTopicVerseRow.chapter &&
+              verseRow.verse < bestTopicVerseRow.verse)));
 
       if (isTopicBetter) {
         bestTopicEffectiveScore = effectiveScore;
@@ -1206,7 +1224,7 @@ function buildWhyThisBookMatters(
   const themePhrase =
     topThemes.length > 1
       ? topThemes.slice(0, -1).join(', ') + ' and ' + topThemes[topThemes.length - 1]
-      : topThemes[0] ?? 'this theme';
+      : (topThemes[0] ?? 'this theme');
 
   // Select a genre-appropriate explanation template.
   switch (genre) {
@@ -1238,122 +1256,122 @@ function buildWhyThisBookMatters(
 // Values are clean, human-readable labels shown in the output.
 const TOPIC_LABEL_MAP: Record<string, string> = {
   'AFFLICTIONS AND ADVERSITIES': 'affliction',
-  'AFFLICTIONS': 'affliction',
-  'ADVERSITY': 'adversity',
-  'ANGER': 'anger',
-  'ANXIETY': 'anxiety',
-  'APOSTASY': 'apostasy',
-  'ATONEMENT': 'atonement',
-  'BAPTISM': 'baptism',
-  'BLESSINGS': 'blessing',
-  'CALLING': 'calling',
-  'CHARITY': 'generosity',
-  'CHILDREN': 'children',
+  AFFLICTIONS: 'affliction',
+  ADVERSITY: 'adversity',
+  ANGER: 'anger',
+  ANXIETY: 'anxiety',
+  APOSTASY: 'apostasy',
+  ATONEMENT: 'atonement',
+  BAPTISM: 'baptism',
+  BLESSINGS: 'blessing',
+  CALLING: 'calling',
+  CHARITY: 'generosity',
+  CHILDREN: 'children',
   'CHILDREN OF ISRAEL': 'Israel',
-  'CHRIST': 'Christ',
-  'CHURCH': 'the church',
-  'COMFORT': 'comfort',
-  'COMMANDMENTS': 'commandments',
-  'COMPASSION': 'compassion',
-  'CONSCIENCE': 'conscience',
-  'CONTENTMENT': 'contentment',
-  'COURAGE': 'courage',
-  'COVENANT': 'covenant',
-  'COVETOUSNESS': 'covetousness',
-  'CREATION': 'creation',
-  'DEATH': 'death',
-  'DELIVERANCE': 'deliverance',
-  'DISCIPLESHIP': 'discipleship',
-  'DISCIPLINE': 'discipline',
+  CHRIST: 'Christ',
+  CHURCH: 'the church',
+  COMFORT: 'comfort',
+  COMMANDMENTS: 'commandments',
+  COMPASSION: 'compassion',
+  CONSCIENCE: 'conscience',
+  CONTENTMENT: 'contentment',
+  COURAGE: 'courage',
+  COVENANT: 'covenant',
+  COVETOUSNESS: 'covetousness',
+  CREATION: 'creation',
+  DEATH: 'death',
+  DELIVERANCE: 'deliverance',
+  DISCIPLESHIP: 'discipleship',
+  DISCIPLINE: 'discipline',
   'DIVINE GUIDANCE': 'guidance',
   'DIVINE PROTECTION': 'protection',
   'DIVINE SOVEREIGNTY': 'sovereignty',
-  'DOUBT': 'doubt',
-  'ELECTION': 'election',
-  'ENDURANCE': 'endurance',
+  DOUBT: 'doubt',
+  ELECTION: 'election',
+  ENDURANCE: 'endurance',
   'ETERNAL LIFE': 'eternal life',
-  'EVANGELISM': 'evangelism',
-  'EVIL': 'evil',
-  'EXILE': 'exile',
-  'FAITH': 'faith',
-  'FAITHFULNESS': 'faithfulness',
-  'FAMILY': 'family',
-  'FASTING': 'fasting',
-  'FEAR': 'fear',
+  EVANGELISM: 'evangelism',
+  EVIL: 'evil',
+  EXILE: 'exile',
+  FAITH: 'faith',
+  FAITHFULNESS: 'faithfulness',
+  FAMILY: 'family',
+  FASTING: 'fasting',
+  FEAR: 'fear',
   'FEAR OF GOD': 'fear of God',
-  'FORGIVENESS': 'forgiveness',
-  'FRIENDSHIP': 'friendship',
-  'GENEROSITY': 'generosity',
-  'GLORIFICATION': 'glorification',
-  'GLORY': 'glory',
-  'GOD': 'God',
-  'GRACE': 'grace',
-  'GRATITUDE': 'gratitude',
-  'GRIEF': 'grief',
-  'GUIDANCE': 'guidance',
-  'HEALING': 'healing',
-  'HOLINESS': 'holiness',
+  FORGIVENESS: 'forgiveness',
+  FRIENDSHIP: 'friendship',
+  GENEROSITY: 'generosity',
+  GLORIFICATION: 'glorification',
+  GLORY: 'glory',
+  GOD: 'God',
+  GRACE: 'grace',
+  GRATITUDE: 'gratitude',
+  GRIEF: 'grief',
+  GUIDANCE: 'guidance',
+  HEALING: 'healing',
+  HOLINESS: 'holiness',
   'HOLY SPIRIT': 'the Holy Spirit',
-  'HOPE': 'hope',
-  'HUMILITY': 'humility',
-  'IDOLATRY': 'idolatry',
-  'ISRAEL': 'Israel',
+  HOPE: 'hope',
+  HUMILITY: 'humility',
+  IDOLATRY: 'idolatry',
+  ISRAEL: 'Israel',
   'JESUS CHRIST': 'Jesus Christ',
-  'JOY': 'joy',
-  'JUDGMENT': 'judgment',
-  'JUSTICE': 'justice',
+  JOY: 'joy',
+  JUDGMENT: 'judgment',
+  JUSTICE: 'justice',
   'KINGDOM OF GOD': 'the kingdom of God',
-  'LAW': 'the law',
-  'LAMENT': 'lament',
-  'LEADERSHIP': 'leadership',
-  'LIGHT': 'light',
-  'LONELINESS': 'loneliness',
-  'LORD': 'the Lord',
-  'LOVE': 'love',
-  'LOVE OF GOD': 'God\'s love',
-  'MARRIAGE': 'marriage',
-  'MERCY': 'mercy',
-  'MISSIONS': 'missions',
-  'OBEDIENCE': 'obedience',
-  'OMNIPOTENCE': 'God\'s power',
-  'PATIENCE': 'patience',
-  'PEACE': 'peace',
-  'PERSEVERANCE': 'perseverance',
-  'PRAISE': 'praise',
-  'PRAYER': 'prayer',
-  'PRIDE': 'pride',
-  'PROPHECY': 'prophecy',
-  'PROVIDENCE': 'providence',
-  'PURIFICATION': 'purification',
-  'REDEMPTION': 'redemption',
-  'RENEWAL': 'renewal',
-  'REPENTANCE': 'repentance',
-  'RESTORATION': 'restoration',
-  'RESURRECTION': 'resurrection',
-  'REVELATION': 'revelation',
-  'RIGHTEOUSNESS': 'righteousness',
-  'SACRIFICE': 'sacrifice',
-  'SALVATION': 'salvation',
-  'SANCTIFICATION': 'sanctification',
-  'SERVANT': 'servanthood',
-  'SERVICE': 'service',
-  'SIN': 'sin',
-  'SOVEREIGNTY OF GOD': 'God\'s sovereignty',
-  'STRENGTH': 'strength',
-  'SUFFERING': 'suffering',
-  'TEMPTATION': 'temptation',
-  'THANKSGIVING': 'thanksgiving',
-  'TRIALS': 'trials',
-  'TRUST': 'trust',
-  'TRUTH': 'truth',
-  'UNFAITHFULNESS': 'unfaithfulness',
-  'UNITY': 'unity',
-  'VICTORY': 'victory',
-  'WISDOM': 'wisdom',
-  'WORKS': 'works',
-  'WORSHIP': 'worship',
-  'WRATH': 'wrath',
-  'WRATH OF GOD': 'God\'s wrath',
+  LAW: 'the law',
+  LAMENT: 'lament',
+  LEADERSHIP: 'leadership',
+  LIGHT: 'light',
+  LONELINESS: 'loneliness',
+  LORD: 'the Lord',
+  LOVE: 'love',
+  'LOVE OF GOD': "God's love",
+  MARRIAGE: 'marriage',
+  MERCY: 'mercy',
+  MISSIONS: 'missions',
+  OBEDIENCE: 'obedience',
+  OMNIPOTENCE: "God's power",
+  PATIENCE: 'patience',
+  PEACE: 'peace',
+  PERSEVERANCE: 'perseverance',
+  PRAISE: 'praise',
+  PRAYER: 'prayer',
+  PRIDE: 'pride',
+  PROPHECY: 'prophecy',
+  PROVIDENCE: 'providence',
+  PURIFICATION: 'purification',
+  REDEMPTION: 'redemption',
+  RENEWAL: 'renewal',
+  REPENTANCE: 'repentance',
+  RESTORATION: 'restoration',
+  RESURRECTION: 'resurrection',
+  REVELATION: 'revelation',
+  RIGHTEOUSNESS: 'righteousness',
+  SACRIFICE: 'sacrifice',
+  SALVATION: 'salvation',
+  SANCTIFICATION: 'sanctification',
+  SERVANT: 'servanthood',
+  SERVICE: 'service',
+  SIN: 'sin',
+  'SOVEREIGNTY OF GOD': "God's sovereignty",
+  STRENGTH: 'strength',
+  SUFFERING: 'suffering',
+  TEMPTATION: 'temptation',
+  THANKSGIVING: 'thanksgiving',
+  TRIALS: 'trials',
+  TRUST: 'trust',
+  TRUTH: 'truth',
+  UNFAITHFULNESS: 'unfaithfulness',
+  UNITY: 'unity',
+  VICTORY: 'victory',
+  WISDOM: 'wisdom',
+  WORKS: 'works',
+  WORSHIP: 'worship',
+  WRATH: 'wrath',
+  'WRATH OF GOD': "God's wrath",
 };
 
 // Transforms a raw Nave's topic name into a user-facing thematic label.
@@ -1577,9 +1595,23 @@ async function fetchAnchorPassageData(
 // Keywords that indicate a comfort/hope/faithfulness theme in the query.
 // Used by Prophecy clustering to bias toward consolation sections.
 const CONSOLATION_KEYWORDS = [
-  'comfort', 'hope', 'faithful', 'faithfulness', 'promise', 'restore',
-  'restoration', 'consolation', 'peace', 'salvation', 'redemption',
-  'deliverance', 'mercy', 'grace', 'blessing', 'renewal', 'trust',
+  'comfort',
+  'hope',
+  'faithful',
+  'faithfulness',
+  'promise',
+  'restore',
+  'restoration',
+  'consolation',
+  'peace',
+  'salvation',
+  'redemption',
+  'deliverance',
+  'mercy',
+  'grace',
+  'blessing',
+  'renewal',
+  'trust',
 ];
 
 // Returns true when the query topic semantically relates to comfort or hope.
@@ -1611,12 +1643,24 @@ function buildSpans(
   chapters: AnchorChapterRow[],
   maxGap: number,
 ): Array<{ start: number; end: number; totalHits: number; minVerse: number; maxVerse: number }> {
-  const spans: Array<{ start: number; end: number; totalHits: number; minVerse: number; maxVerse: number }> = [];
-  let currentSpan: typeof spans[0] | null = null;
+  const spans: Array<{
+    start: number;
+    end: number;
+    totalHits: number;
+    minVerse: number;
+    maxVerse: number;
+  }> = [];
+  let currentSpan: (typeof spans)[0] | null = null;
 
   for (const row of chapters) {
     if (!currentSpan) {
-      currentSpan = { start: row.chapter, end: row.chapter, totalHits: row.hit_count, minVerse: row.min_verse, maxVerse: row.max_verse };
+      currentSpan = {
+        start: row.chapter,
+        end: row.chapter,
+        totalHits: row.hit_count,
+        minVerse: row.min_verse,
+        maxVerse: row.max_verse,
+      };
     } else if (row.chapter - currentSpan.end <= maxGap) {
       currentSpan.end = row.chapter;
       currentSpan.totalHits += row.hit_count;
@@ -1624,7 +1668,13 @@ function buildSpans(
       currentSpan.maxVerse = Math.max(currentSpan.maxVerse, row.max_verse);
     } else {
       spans.push(currentSpan);
-      currentSpan = { start: row.chapter, end: row.chapter, totalHits: row.hit_count, minVerse: row.min_verse, maxVerse: row.max_verse };
+      currentSpan = {
+        start: row.chapter,
+        end: row.chapter,
+        totalHits: row.hit_count,
+        minVerse: row.min_verse,
+        maxVerse: row.max_verse,
+      };
     }
   }
   if (currentSpan) spans.push(currentSpan);
@@ -1648,10 +1698,7 @@ function buildSpans(
 //
 // Epistle and default: Density-based consecutive clustering (unchanged).
 
-function clusterPoetry(
-  rows: AnchorChapterRow[],
-  bookName: string,
-): string[] {
+function clusterPoetry(rows: AnchorChapterRow[], bookName: string): string[] {
   if (rows.length === 0) return [];
   // Return up to 3 individual dense chapters — no consecutive merging.
   const sorted = [...rows].sort((a, b) => b.hit_count - a.hit_count);
@@ -1700,7 +1747,7 @@ function clusterNarrative(
   const arcRepresentatives: AnchorChapterRow[] = [];
   for (const arcRows of [entryRows, crisisRows, resolutionRows]) {
     if (arcRows.length === 0) continue;
-    const densest = arcRows.reduce((best, r) => r.hit_count > best.hit_count ? r : best);
+    const densest = arcRows.reduce((best, r) => (r.hit_count > best.hit_count ? r : best));
     arcRepresentatives.push(densest);
   }
 
@@ -1711,9 +1758,11 @@ function clusterNarrative(
   const spans = buildSpans(arcRepresentatives, 3);
   spans.sort((a, b) => b.totalHits - a.totalHits);
 
-  return spans.slice(0, 3).map((span) =>
-    formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse)
-  );
+  return spans
+    .slice(0, 3)
+    .map((span) =>
+      formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse),
+    );
 }
 
 function clusterProphecy(
@@ -1752,9 +1801,11 @@ function clusterProphecy(
   const spans = buildSpans(topChapters, 2);
   spans.sort((a, b) => b.totalHits - a.totalHits);
 
-  return spans.slice(0, 3).map((span) =>
-    formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse)
-  );
+  return spans
+    .slice(0, 3)
+    .map((span) =>
+      formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse),
+    );
 }
 
 // Clusters chapter rows for a single book into passage range strings using a
@@ -1789,12 +1840,7 @@ function clusterToPassageRanges(
   }
 
   // Narrative: arc-based clustering (Law, History, Gospel, Acts).
-  if (
-    genre === 'Law' ||
-    genre === 'History' ||
-    genre === 'Gospel' ||
-    genre === 'Acts'
-  ) {
+  if (genre === 'Law' || genre === 'History' || genre === 'Gospel' || genre === 'Acts') {
     return clusterNarrative(rows, bookName, totalBookChapters);
   }
 
@@ -1824,9 +1870,11 @@ function clusterToPassageRanges(
   spans.sort((a, b) => b.totalHits - a.totalHits);
 
   // Emit up to 3 passage range strings.
-  return spans.slice(0, 3).map((span) =>
-    formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse)
-  );
+  return spans
+    .slice(0, 3)
+    .map((span) =>
+      formatPassageRange(bookName, span.start, span.end, span.minVerse, span.maxVerse),
+    );
 }
 
 // Builds a genre-aware narrative_reason string when detectNarrative returns a result.
@@ -1842,12 +1890,8 @@ function buildNarrativeReason(
   const genre = BOOK_GENRE[candidate.book_name] ?? 'Unknown';
   const chapterRange = `${candidate.book_name} ${candidate.min_chapter}–${candidate.max_chapter}`;
 
-  const topThemes = themesMatched && themesMatched.length > 0
-    ? themesMatched.slice(0, 2)
-    : [];
-  const themeClause = topThemes.length > 0
-    ? ` — particularly ${topThemes.join(' and ')}`
-    : '';
+  const topThemes = themesMatched && themesMatched.length > 0 ? themesMatched.slice(0, 2) : [];
+  const themeClause = topThemes.length > 0 ? ` — particularly ${topThemes.join(' and ')}` : '';
 
   switch (genre) {
     case 'Law':
@@ -1928,9 +1972,7 @@ function buildQueryAlignmentNote(
 ): string {
   const topThemes = themesMatched.slice(0, 2);
   const themePhrase =
-    topThemes.length > 1
-      ? topThemes[0] + ' and ' + topThemes[1]
-      : topThemes[0] ?? queryTopic;
+    topThemes.length > 1 ? topThemes[0] + ' and ' + topThemes[1] : (topThemes[0] ?? queryTopic);
 
   // Choose phrasing based on how well both signals fired.
   const hasStrongSemanticSignal = semanticHits >= 2;
@@ -1971,9 +2013,7 @@ function buildQueryAlignmentNote(
 // seed-verse counts in books that reference the topic in a different story context.
 // Example: ARK covers both Noah's ark (Genesis) and the Ark of the Covenant
 // (Exodus/Numbers); including it inflates seed counts for Exodus on a Noah query.
-const POLYSEMOUS_NARRATIVE_TOPICS = new Set([
-  'ARK', 'TEMPLE', 'TABERNACLE', 'ISRAEL', 'CHURCH',
-]);
+const POLYSEMOUS_NARRATIVE_TOPICS = new Set(['ARK', 'TEMPLE', 'TABERNACLE', 'ISRAEL', 'CHURCH']);
 
 // ─── Major witness builder ────────────────────────────────────────────────────
 
@@ -2065,7 +2105,7 @@ async function buildMajorWitnesses(
     if (seedCandidates.length === 0) {
       console.error(
         `[topical_search] narrative mode: seedCandidates is empty for query="${queryTopic}", ` +
-        `seedIdsToUse=[${seedIdsToUse.join(',')}]`,
+          `seedIdsToUse=[${seedIdsToUse.join(',')}]`,
       );
     }
 
@@ -2077,8 +2117,10 @@ async function buildMajorWitnesses(
     // from this check since they legitimately cross-reference OT narratives in their own
     // chapter structure (e.g. Heb 11:7, 1 Pet 3:20 referencing Noah).
     const primarySeedBookId = seedCandidates.length > 0 ? seedCandidates[0].book_id : undefined;
-    const primarySeedChapterMin = seedCandidates.length > 0 ? seedCandidates[0].min_chapter : undefined;
-    const primarySeedChapterMax = seedCandidates.length > 0 ? seedCandidates[0].max_chapter : undefined;
+    const primarySeedChapterMin =
+      seedCandidates.length > 0 ? seedCandidates[0].min_chapter : undefined;
+    const primarySeedChapterMax =
+      seedCandidates.length > 0 ? seedCandidates[0].max_chapter : undefined;
     // "Narrow" narrative: the primary story spans fewer than 15 chapters.
     // This threshold covers self-contained story units (e.g. Genesis 6-9 for Noah,
     // ~4 chapters) while excluding book-wide narratives (e.g. Moses across Exodus,
@@ -2091,17 +2133,12 @@ async function buildMajorWitnesses(
       primarySeedChapterMax - primarySeedChapterMin < 15;
 
     for (const sc of seedCandidates) {
-      if (
-        primaryNarrativeIsNarrow &&
-        sc.book_id !== primarySeedBookId &&
-        sc.testament === 'OT'
-      ) {
+      if (primaryNarrativeIsNarrow && sc.book_id !== primarySeedBookId && sc.testament === 'OT') {
         // Check chapter range overlap with primary narrative span.
         // No overlap means this OT book's seed verses are about a different
         // person or event (disambiguation case).
         const overlaps =
-          sc.min_chapter <= primarySeedChapterMax! &&
-          sc.max_chapter >= primarySeedChapterMin!;
+          sc.min_chapter <= primarySeedChapterMax! && sc.max_chapter >= primarySeedChapterMin!;
         if (!overlaps) {
           // Exclude from seed counts — this OT book references the topic in
           // a different context (different story, same topic name).
@@ -2115,10 +2152,7 @@ async function buildMajorWitnesses(
   // Count semantic verse hits per book — direct embedding-based relevance signal.
   const semanticHitsPerBook = new Map<number, number>();
   for (const coord of semanticCoords.values()) {
-    semanticHitsPerBook.set(
-      coord.book_id,
-      (semanticHitsPerBook.get(coord.book_id) ?? 0) + 1,
-    );
+    semanticHitsPerBook.set(coord.book_id, (semanticHitsPerBook.get(coord.book_id) ?? 0) + 1);
   }
 
   // Fetch salience using the broad topic set (including co-occurring topics) and
@@ -2139,14 +2173,13 @@ async function buildMajorWitnesses(
   // co-occurring topics (TABERNACLE, ISRAEL) that drag Exodus to the top for Noah.
   const isNarrativeModeForFilter = narrativeContext?.narrativeMode === true;
   const narrativePrimaryBookIdForFilter = isNarrativeModeForFilter
-    ? (seedCandidates.length > 0 ? seedCandidates[0].book_id : candidates[0]?.book_id)
+    ? seedCandidates.length > 0
+      ? seedCandidates[0].book_id
+      : candidates[0]?.book_id
     : undefined;
 
   const qualified = candidates.filter((c) => {
-    if (
-      isNarrativeModeForFilter &&
-      c.book_id !== narrativePrimaryBookIdForFilter
-    ) {
+    if (isNarrativeModeForFilter && c.book_id !== narrativePrimaryBookIdForFilter) {
       // Non-primary book in narrative mode: apply stricter thresholds AND
       // require at least one direct seed-topic verse. This eliminates books
       // like Exodus and Numbers for a Noah query (0 NOAH/FLOOD/ARK verses)
@@ -2160,8 +2193,7 @@ async function buildMajorWitnesses(
       );
     }
     return (
-      c.verse_count >= MAJOR_WITNESS_MIN_VERSES &&
-      c.chapter_count >= MAJOR_WITNESS_MIN_CHAPTERS
+      c.verse_count >= MAJOR_WITNESS_MIN_VERSES && c.chapter_count >= MAJOR_WITNESS_MIN_CHAPTERS
     );
   });
 
@@ -2293,9 +2325,7 @@ async function buildMajorWitnesses(
   // Build the candidate list: apply cap + cutoff, but always include the primary book.
   const cappedSlice = scored.slice(0, activeMaxWitnesses);
   const topScoredCandidates = isNarrativeMode
-    ? cappedSlice.filter(
-        (s) => s.witnessScore >= cutoff || s.candidate.book_id === primaryBookId,
-      )
+    ? cappedSlice.filter((s) => s.witnessScore >= cutoff || s.candidate.book_id === primaryBookId)
     : cappedSlice.filter((s) => s.witnessScore >= cutoff);
 
   // Build witnesses concurrently (representative verse may need D1 fallback).
@@ -2307,9 +2337,7 @@ async function buildMajorWitnesses(
         .filter(Boolean);
 
       // Prefer short topic names as narrative labels.
-      const shortTopics = matchedTopics.filter(
-        (t) => t.split(/\s+/).length <= 3,
-      );
+      const shortTopics = matchedTopics.filter((t) => t.split(/\s+/).length <= 3);
       const narrative = detectNarrative(candidate, shortTopics);
 
       // Resolve the topic IDs that caused this book to become a witness.
@@ -2454,10 +2482,7 @@ interface NaveSearchEntry {
   relevance: number;
 }
 
-async function searchNaves(
-  topic: string,
-  limit: number,
-): Promise<Map<string, NaveSearchEntry>> {
+async function searchNaves(topic: string, limit: number): Promise<Map<string, NaveSearchEntry>> {
   // Normalize the topic the same way the ETL does: lowercase.
   const normalized = topic.toLowerCase();
 
@@ -2544,13 +2569,21 @@ async function searchNaves(
 async function searchSemanticFromVector(
   queryVector: number[],
   limit: number,
-): Promise<Map<string, { book_id: number; chapter: number; verse: number; translation_id: number; score: number }>> {
+): Promise<
+  Map<
+    string,
+    { book_id: number; chapter: number; verse: number; translation_id: number; score: number }
+  >
+> {
   const topK = Math.min(limit * VECTORIZE_OVERFETCH_MULTIPLIER, 20);
   const matches = await vectorize.query(queryVector, { topK });
   if (matches.length === 0) return new Map();
 
   // Each match metadata contains book_id, chapter, verse, translation_id.
-  const coordMap = new Map<string, { book_id: number; chapter: number; verse: number; translation_id: number; score: number }>();
+  const coordMap = new Map<
+    string,
+    { book_id: number; chapter: number; verse: number; translation_id: number; score: number }
+  >();
 
   for (const match of matches) {
     const meta = match.metadata;
@@ -2567,7 +2600,13 @@ async function searchSemanticFromVector(
     // We'll fetch the actual book name via D1 query below.
     const key = `${bookId}:${chapter}:${verse}`;
     if (!coordMap.has(key)) {
-      coordMap.set(key, { book_id: bookId, chapter, verse, translation_id: translationId, score: match.score });
+      coordMap.set(key, {
+        book_id: bookId,
+        chapter,
+        verse,
+        translation_id: translationId,
+        score: match.score,
+      });
     }
   }
 
@@ -2620,9 +2659,7 @@ async function fetchVerseTexts(
 
   // Issue all chunk queries concurrently.
   const statements = chunks.map(buildVerseChunkStatement);
-  const resultSets = await Promise.all(
-    statements.map((stmt) => d1.query(stmt.sql, stmt.params))
-  );
+  const resultSets = await Promise.all(statements.map((stmt) => d1.query(stmt.sql, stmt.params)));
 
   const verseMap = new Map<string, VerseRow>();
 
@@ -2647,7 +2684,10 @@ function capConsecutiveVerses(
   navesMap: Map<string, NaveSearchEntry>,
 ): Map<string, NaveSearchEntry> {
   // Group entries by book:chapter.
-  const byChapter = new Map<string, Array<{ key: string; verse: number; entry: NaveSearchEntry }>>();
+  const byChapter = new Map<
+    string,
+    Array<{ key: string; verse: number; entry: NaveSearchEntry }>
+  >();
 
   for (const [key, entry] of navesMap) {
     const { book, chapter, verse } = entry.result.citation;
@@ -2706,23 +2746,36 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
   // Graceful degradation: if topic index is not configured, searchSemanticTopicsAndBooks
   // returns empty arrays — fall back to Nave's LIKE for witnesses.
   // Topic + book results share one Vectorize query (saves an HTTP round-trip).
-  const semanticCoordsPromise = queryVector.length > 0
-    ? searchSemanticFromVector(queryVector, limit)
-    : Promise.resolve(new Map<string, { book_id: number; chapter: number; verse: number; translation_id: number; score: number }>());
+  const semanticCoordsPromise =
+    queryVector.length > 0
+      ? searchSemanticFromVector(queryVector, limit)
+      : Promise.resolve(
+          new Map<
+            string,
+            {
+              book_id: number;
+              chapter: number;
+              verse: number;
+              translation_id: number;
+              score: number;
+            }
+          >(),
+        );
 
-  const semanticTopicsAndBooksPromise = queryVector.length > 0
-    ? searchSemanticTopicsAndBooks(queryVector)
-    : Promise.resolve({ topics: [] as Array<{ id: number; name: string; score: number }>, books: [] as Array<{ book_id: number; score: number }> });
+  const semanticTopicsAndBooksPromise =
+    queryVector.length > 0
+      ? searchSemanticTopicsAndBooks(queryVector)
+      : Promise.resolve({
+          topics: [] as Array<{ id: number; name: string; score: number }>,
+          books: [] as Array<{ book_id: number; score: number }>,
+        });
 
   // Run LIKE topic expansion in parallel with Vectorize queries to avoid
   // sequential latency. Both sources are needed for comprehensive coverage.
   const likeTopicsPromise = queryExpandedTopicsByLike(topic);
 
-  const [{ topics: semanticTopics, books: semanticBooks }, semanticCoords, likeTopics] = await Promise.all([
-    semanticTopicsAndBooksPromise,
-    semanticCoordsPromise,
-    likeTopicsPromise,
-  ]);
+  const [{ topics: semanticTopics, books: semanticBooks }, semanticCoords, likeTopics] =
+    await Promise.all([semanticTopicsAndBooksPromise, semanticCoordsPromise, likeTopicsPromise]);
 
   // Detect whether the query names a specific biblical narrative or figure.
   // This is done after LIKE topics resolve so we can use them as a signal.
@@ -2752,9 +2805,7 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
   // concentrated (high salience = canonical for a specific book) vs spread
   // evenly (generic topics that would inflate all books equally).
   const coTopicIds = cooccurringTopics.map((t) => t.id);
-  const coSalienceEntries = coTopicIds.length > 0
-    ? await fetchCooccurringSalience(coTopicIds)
-    : [];
+  const coSalienceEntries = coTopicIds.length > 0 ? await fetchCooccurringSalience(coTopicIds) : [];
 
   // Include co-occurring topics in aggregation ONLY if they are among the
   // top co-occurring topics by shared verse count AND have high salience
@@ -2815,7 +2866,19 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
   const seedTopicIdSet = new Set(seedTopicIds);
   const majorWitnesses =
     finalExpandedTopics.length > 0
-      ? await buildMajorWitnesses(finalExpandedTopics, salienceTopicIds, topicRelevanceWeight, semanticBooks, semanticCoords, semanticVerseMap, topic, narrativeContext ?? undefined, seedTopicIdSet, semanticScoreById, likeTopicIdSet)
+      ? await buildMajorWitnesses(
+          finalExpandedTopics,
+          salienceTopicIds,
+          topicRelevanceWeight,
+          semanticBooks,
+          semanticCoords,
+          semanticVerseMap,
+          topic,
+          narrativeContext ?? undefined,
+          seedTopicIdSet,
+          semanticScoreById,
+          likeTopicIdSet,
+        )
       : [];
 
   // Phase 4: Existing merge + witness interleave + match reasons.
@@ -2848,7 +2911,7 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
       const topicName = existing.result.match_reason?.replace("Nave's Topical Bible: ", '') ?? '';
       existing.result.match_reason = topicName
         ? `Nave's Topical Bible: ${topicName} + Semantic similarity`
-        : 'Nave\'s Topical Bible + Semantic similarity';
+        : "Nave's Topical Bible + Semantic similarity";
     } else {
       const citation: Citation = {
         book: verseRow.book_name,
@@ -2889,7 +2952,8 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
 
   // Split Nave's results into 'both' (matched semantic too) and 'naves'-only.
   const bothEntries: Array<{ unifiedKey: string; result: TopicalResult }> = [];
-  const navesOnlyEntries: Array<{ unifiedKey: string; relevance: number; result: TopicalResult }> = [];
+  const navesOnlyEntries: Array<{ unifiedKey: string; relevance: number; result: TopicalResult }> =
+    [];
 
   for (const [key, entry] of navesResultsCapped) {
     if (entry.result.source === 'both') {
@@ -2928,12 +2992,14 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
   const naveOnlyOverflow = navesOnlyBudget - navesOnlySlice.length;
   const semanticOverflow = semanticBudget - semanticSlice.length;
 
-  const extraSemantic = naveOnlyOverflow > 0
-    ? semanticPool.slice(semanticBudget, semanticBudget + naveOnlyOverflow)
-    : [];
-  const extraNaves = semanticOverflow > 0
-    ? navesOnlyPool.slice(navesOnlyBudget, navesOnlyBudget + semanticOverflow)
-    : [];
+  const extraSemantic =
+    naveOnlyOverflow > 0
+      ? semanticPool.slice(semanticBudget, semanticBudget + naveOnlyOverflow)
+      : [];
+  const extraNaves =
+    semanticOverflow > 0
+      ? navesOnlyPool.slice(navesOnlyBudget, navesOnlyBudget + semanticOverflow)
+      : [];
 
   // Final ordering: 'both' first (by semantic score), then remaining by relevance.
   const mergedResults = [
@@ -2952,16 +3018,13 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
     // We need candidate book_ids for the interleave check — re-use aggregation
     // data already computed. To avoid another D1 round-trip, derive book_ids
     // from semanticCoords and verseMap that we already have in memory.
-    const witnessBookNames = new Set(
-      majorWitnesses.map((w) => w.book.toLowerCase()),
-    );
+    const witnessBookNames = new Set(majorWitnesses.map((w) => w.book.toLowerCase()));
 
     const witnessVerseCount = mergedResults.filter((r) =>
       witnessBookNames.has(r.citation.book.toLowerCase()),
     ).length;
 
-    const witnessRatio =
-      mergedResults.length > 0 ? witnessVerseCount / mergedResults.length : 0;
+    const witnessRatio = mergedResults.length > 0 ? witnessVerseCount / mergedResults.length : 0;
 
     if (witnessRatio < 0.15) {
       // Collect witness-book verse candidates from semantic pool not already in results.
@@ -3022,11 +3085,11 @@ topicalSearch.annotations = {
 
 topicalSearch.description =
   'Research what the Bible teaches about a topic. Best for broad theological questions, especially "What does the Bible say about X?" queries. ' +
-  'Returns both direct verse hits and major_witnesses: the books, narratives, and passages that are the Bible\'s principal treatments of the topic. ' +
-  'Combines Nave\'s curated Topical Bible (5,319 categories) with AI semantic search. ' +
+  "Returns both direct verse hits and major_witnesses: the books, narratives, and passages that are the Bible's principal treatments of the topic. " +
+  "Combines Nave's curated Topical Bible (5,319 categories) with AI semantic search. " +
   'Works for single topics ("forgiveness", "prayer") and compound themes ("God\'s faithfulness during suffering", "hope in the face of death"). ' +
   'Prefer this over semantic_search when the answer should include major biblical witnesses across passages, narratives, books, or genres. ' +
-  'Major witnesses include witness_strength (central/strong/supporting) and query_alignment_note to explain how the book\'s evidence connects to your query. ' +
+  "Major witnesses include witness_strength (central/strong/supporting) and query_alignment_note to explain how the book's evidence connects to your query. " +
   'For story/narrative queries (e.g., "Noah and the ark", "the Exodus", "David and Goliath"): topical_search identifies the primary narrative book and anchor verse range. ' +
   'After getting results, pick a representative verse from the story unit (cross_references takes a single verse, not a range), then use cross_references on that anchor verse to find how other books reference the story, and use semantic_search for verse-level exploration within the story unit. ' +
   'For deeper study: use cross_references to expand a verse found in the results, semantic_search for additional verse-level discovery, find_text for keyword-based follow-up searches, or word_study for original-language analysis of key terms.';
@@ -3036,7 +3099,7 @@ topicalSearch.input = {
     required: true,
     description:
       'The topic to search for. Accepts single topics (e.g., "forgiveness", "prayer") or compound themes (e.g., "God\'s faithfulness during suffering"). ' +
-      'Nave\'s index is searched by keyword match; semantic search finds conceptually related verses.',
+      "Nave's index is searched by keyword match; semantic search finds conceptually related verses.",
     minLength: 1,
   }),
   limit: T.number({

--- a/src/tools/topical-search.ts
+++ b/src/tools/topical-search.ts
@@ -10,8 +10,8 @@
 //   4. Build major witnesses from expanded topics + semantic results
 //   5. Return combined results with source attribution and match explanations
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1, vectorize, vectorizeTopics, workersAi } from '../lib/cloudflare.js';
 import type { Citation } from '../lib/bible-utils.js';
 import { getTranslation, ensureInitialized } from '../lib/bible-utils.js';
@@ -2727,10 +2727,10 @@ function capConsecutiveVerses(
 
 // ─── Tool handler ─────────────────────────────────────────────────────────────
 
-const topicalSearch: ToolHandler = async (args, _ask?) => {
+const topicalSearch: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
-  const { topic, limit: limitArg } = args as { topic: string; limit?: number };
+  const { topic, limit: limitArg } = req as { topic: string; limit?: number };
   const limit = Math.min(Math.max(limitArg ?? 20, 1), 50);
 
   // Phase 1: Embed query once, fire Nave's search concurrently.
@@ -3073,7 +3073,7 @@ const topicalSearch: ToolHandler = async (args, _ask?) => {
     major_witnesses: majorWitnesses,
   };
 
-  return response;
+  res.send(response);
 };
 
 topicalSearch.annotations = {

--- a/src/tools/word-study.ts
+++ b/src/tools/word-study.ts
@@ -86,7 +86,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
   // silently falling back to KJV (matches behavior of find-text and concordance).
   if (translation !== undefined && !isValidTranslation(translation)) {
     throw new Error(
-      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`
+      `Unknown translation "${translation}". Use the bible://translations resource to list available translations.`,
     );
   }
 
@@ -135,13 +135,13 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
      LEFT JOIN lexicon_entries le ON le.strongs_number = m.strongs_number
      WHERE m.book_id = ? AND m.chapter = ? AND m.verse = ?
      ORDER BY m.word_position`,
-    [resolvedBook.id, chapter, verse]
+    [resolvedBook.id, chapter, verse],
   );
 
   if (morphResult.results.length === 0) {
     throw new Error(
       `No morphology data found for ${resolvedBook.name} ${chapter}:${verse}. ` +
-        'Original language data may not be available for this verse.'
+        'Original language data may not be available for this verse.',
     );
   }
 
@@ -175,7 +175,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
   if (!matchedRow) {
     throw new Error(
       `Word "${word}" not found in ${resolvedBook.name} ${chapter}:${verse}. ` +
-        `Try a word position (e.g. "1", "2", "3") or an English word that appears in the verse.`
+        `Try a word position (e.g. "1", "2", "3") or an English word that appears in the verse.`,
     );
   }
 
@@ -189,7 +189,8 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
           lemma: (row['lemma'] as string) ?? '',
           strongs_number: (row['strongs_number'] as string) ?? '',
           transliteration: (row['transliteration'] as string) ?? '',
-          short_definition: (row['lexicon_short_def'] as string) ?? (row['strongs_definition'] as string) ?? '',
+          short_definition:
+            (row['lexicon_short_def'] as string) ?? (row['strongs_definition'] as string) ?? '',
         }))
       : [];
 
@@ -208,7 +209,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
       (row) =>
         row['word_position'] !== position &&
         typeof row['strongs_number'] === 'string' &&
-        (row['strongs_number'] as string).length > 0
+        (row['strongs_number'] as string).length > 0,
     );
 
     const note =
@@ -244,28 +245,27 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
   }
 
   // 5–8. Issue all remaining queries concurrently.
-  const [strongsResult, lexiconResult, otherVersesMorphResult, countResult] =
-    await Promise.all([
-      // 5. Strong's entry.
-      d1.query(
-        `SELECT original_word, transliteration, definition, language
+  const [strongsResult, lexiconResult, otherVersesMorphResult, countResult] = await Promise.all([
+    // 5. Strong's entry.
+    d1.query(
+      `SELECT original_word, transliteration, definition, language
               FROM strongs
               WHERE prefixed_number = ?`,
-        [strongsNumber]
-      ),
-      // 6. Lexicon entry (BDB for Hebrew, Thayer for Greek).
-      d1.query(
-        `SELECT short_def, long_def
+      [strongsNumber],
+    ),
+    // 6. Lexicon entry (BDB for Hebrew, Thayer for Greek).
+    d1.query(
+      `SELECT short_def, long_def
               FROM lexicon_entries
               WHERE strongs_number = ?
               LIMIT 1`,
-        [strongsNumber]
-      ),
-      // 7. Other verses with the same strongs_number (up to 20, canonical order).
-      //    JOIN verses and books inline to return verse text and book name
-      //    in a single round-trip.
-      d1.query(
-        `SELECT DISTINCT m.book_id, m.chapter, m.verse,
+      [strongsNumber],
+    ),
+    // 7. Other verses with the same strongs_number (up to 20, canonical order).
+    //    JOIN verses and books inline to return verse text and book name
+    //    in a single round-trip.
+    d1.query(
+      `SELECT DISTINCT m.book_id, m.chapter, m.verse,
                      v.text AS verse_text,
                      b.name AS book_name
               FROM morphology m
@@ -278,26 +278,26 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
                 AND NOT (m.book_id = ? AND m.chapter = ? AND m.verse = ?)
               ORDER BY m.book_id, m.chapter, m.verse
               LIMIT 20`,
-        [verseTranslationId, strongsNumber, resolvedBook.id, chapter, verse]
-      ),
-      // 8. Total occurrence count (distinct verses).
-      //    String concatenation with '.' as separator is safe here because
-      //    book_id, chapter, and verse are all integers, so a '.' never
-      //    appears in any component value — making each composite key
-      //    unambiguous (e.g. "1.2.3" can only mean book 1, chapter 2, verse 3).
-      d1.query(
-        `SELECT COUNT(DISTINCT (book_id || '.' || chapter || '.' || verse)) AS total
+      [verseTranslationId, strongsNumber, resolvedBook.id, chapter, verse],
+    ),
+    // 8. Total occurrence count (distinct verses).
+    //    String concatenation with '.' as separator is safe here because
+    //    book_id, chapter, and verse are all integers, so a '.' never
+    //    appears in any component value — making each composite key
+    //    unambiguous (e.g. "1.2.3" can only mean book 1, chapter 2, verse 3).
+    d1.query(
+      `SELECT COUNT(DISTINCT (book_id || '.' || chapter || '.' || verse)) AS total
               FROM morphology
               WHERE strongs_number = ?`,
-        [strongsNumber]
-      ),
-    ]);
+      [strongsNumber],
+    ),
+  ]);
 
   // 5. Parse Strong's entry.
   const strongsRow = strongsResult.results[0];
   if (!strongsRow) {
     throw new Error(
-      `Strong's entry not found for number ${strongsNumber}. The database may be incomplete.`
+      `Strong's entry not found for number ${strongsNumber}. The database may be incomplete.`,
     );
   }
 
@@ -310,7 +310,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
   // Build other occurrences directly from the inline JOIN result — no extra round-trip needed.
   const otherOccurrences = buildOtherOccurrencesInline(
     otherVersesMorphResult.results,
-    verseTranslationAbbrev
+    verseTranslationAbbrev,
   );
 
   // Build source citation — use the first translation_id found for this verse.
@@ -318,7 +318,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
     resolvedBook,
     chapter,
     verse,
-    'ORIG' // Morphology is translation-independent; use canonical marker.
+    'ORIG', // Morphology is translation-independent; use canonical marker.
   );
 
   const disambiguationNote =
@@ -366,20 +366,20 @@ function normalizePos(p: string): string {
 
 function matchByPosition(
   wordParam: string,
-  morphRows: Record<string, unknown>[]
+  morphRows: Record<string, unknown>[],
 ): Record<string, unknown> | undefined {
   const normalizedParam = normalizePos(wordParam);
 
   // Exact match first (handles '1a', '2b', or plain '1' when only one row).
   const exact = morphRows.find(
-    (row) => normalizePos(String(row['word_position'])) === normalizedParam
+    (row) => normalizePos(String(row['word_position'])) === normalizedParam,
   );
   if (exact) return exact;
 
   // If plain integer, also match compound sub-parts (e.g. '1' → '1a', '1b').
   if (/^\d+$/.test(wordParam)) {
     return morphRows.find((row) =>
-      normalizePos(String(row['word_position'])).startsWith(normalizedParam)
+      normalizePos(String(row['word_position'])).startsWith(normalizedParam),
     );
   }
 
@@ -477,13 +477,15 @@ function generateSuffixCandidates(word: string): string[] {
  */
 function matchByEnglishGloss(
   wordParam: string,
-  morphRows: Record<string, unknown>[]
+  morphRows: Record<string, unknown>[],
 ): { first: Record<string, unknown> | undefined; count: number; all: Record<string, unknown>[] } {
   // Inner function: run all matching passes for a given target string.
   // Returns the match result, or { first: undefined, count: 0, all: [] } on no match.
-  function tryMatch(
-    target: string
-  ): { first: Record<string, unknown> | undefined; count: number; all: Record<string, unknown>[] } {
+  function tryMatch(target: string): {
+    first: Record<string, unknown> | undefined;
+    count: number;
+    all: Record<string, unknown>[];
+  } {
     // Build a word-boundary regex so 'sin' doesn't match 'since'.
     const wordBoundaryRe = new RegExp(`\\b${escapeRegex(target)}\\b`, 'i');
 
@@ -532,7 +534,11 @@ function matchByEnglishGloss(
         });
       });
       if (substringMatches.length > 0) {
-        return { first: substringMatches[0], count: substringMatches.length, all: substringMatches };
+        return {
+          first: substringMatches[0],
+          count: substringMatches.length,
+          all: substringMatches,
+        };
       }
     }
 
@@ -571,7 +577,7 @@ function escapeRegex(s: string): string {
  */
 function buildOtherOccurrencesInline(
   rows: Record<string, unknown>[],
-  translationAbbrev: string
+  translationAbbrev: string,
 ): OtherOccurrence[] {
   if (rows.length === 0) return [];
 
@@ -645,7 +651,7 @@ wordStudy.input = {
     description:
       'The word to study. Accepts either: ' +
       '(1) a word position string (e.g. "1", "2", "3", "1a", "1b") corresponding ' +
-      'to the word\'s position in the original language text, or ' +
+      "to the word's position in the original language text, or " +
       '(2) an English surface form (e.g. "love", "grace") that will be matched ' +
       'against the verse text to determine its position.',
     minLength: 1,

--- a/src/tools/word-study.ts
+++ b/src/tools/word-study.ts
@@ -17,8 +17,8 @@
 //   7. Query morphology for other verses with the same strongs_number (LIMIT 20).
 //   8. Count total occurrences (distinct verses with that strongs_number).
 
-import type { ToolHandler } from '@mctx-ai/app';
-import { T } from '@mctx-ai/app';
+import type { ToolHandler, ModelContext, Response as MctxResponse } from '@mctx-ai/mcp';
+import { T } from '@mctx-ai/mcp';
 import { d1 } from '../lib/cloudflare.js';
 import {
   getTranslation,
@@ -71,10 +71,10 @@ interface WordStudyResult {
 
 // ─── Handler ──────────────────────────────────────────────────────────────────
 
-const wordStudy: ToolHandler = async (args, _ask?) => {
+const wordStudy: ToolHandler = async (_mctx: ModelContext, req, res: MctxResponse) => {
   await ensureInitialized();
 
-  const { book, chapter, verse, word, translation } = args as {
+  const { book, chapter, verse, word, translation } = req as {
     book: string;
     chapter: number;
     verse: number;
@@ -241,7 +241,8 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
       note,
     };
 
-    return partialResult;
+    res.send(partialResult);
+    return;
   }
 
   // 5–8. Issue all remaining queries concurrently.
@@ -347,7 +348,7 @@ const wordStudy: ToolHandler = async (args, _ask?) => {
     ...(disambiguationNote && { note: disambiguationNote }),
   };
 
-  return result;
+  res.send(result);
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Two platform updates rolled into one PR. First, mctx's branding evolved to "The best way to Build an MCP Server" with "MCP server" terminology replacing "app." Second, the framework package was renamed (@mctx-ai/app → @mctx-ai/mcp) and bumped to v2 with a new context-first handler signature and a simplified output port.

## What This Does

Replaces all old branding references with current MCP server terminology across every file (README, package.json, CLAUDE.md, scripts, source, tool descriptions, tests) and restructures the README to match mctx's 7-section format. Then bumps the framework from @mctx-ai/app to @mctx-ai/mcp@^2.0.0 (and @mctx-ai/dev@^2.0.0), migrates all tool, resource, and prompt handlers to the new (mctx, req, res) signature, replaces return values with res.send(), and updates tests to match. All quality gates (lint, typecheck, format, tests, build) pass locally. GitHub repo description updated separately via API.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)