### PR TITLE
fix(deps): bump @mctx-ai/mcp to 2.0.2 for workers runtime compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.4",
       "license": "MIT",
       "dependencies": {
-        "@mctx-ai/mcp": "^2.0.0"
+        "@mctx-ai/mcp": "^2.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@mctx-ai/mcp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp/-/mcp-2.0.0.tgz",
-      "integrity": "sha512-NIc8HCrBAs1hD1iVpJjx77Pudnb95PTLlS2+iVrCVYLujfwrxvJ4NQ5BSgWLU8AtuZyBulx/NBnnAnFlIt49Qw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp/-/mcp-2.0.2.tgz",
+      "integrity": "sha512-Dyjtxe/qNb6od/KkRmWzMJhQ2MWgZKY608+fNMWHCyQ4tgJaALg9PqHowyKgK6i5N2svJW/sGzkUz0xrkDbWfQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.scripts.json"
   },
   "dependencies": {
-    "@mctx-ai/mcp": "^2.0.0"
+    "@mctx-ai/mcp": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
## Why

Cloudflare Workers rejected the mctx platform deploy of `bible-study.mctx.ai` with error 10021 because the `@mctx-ai/mcp@2.0.0` framework shipped `createRequire` and `import.meta.url` references — both unsupported Node.js builtins in the Workers runtime. The live server cannot boot until the framework no longer pulls those APIs.

## What This Does

Bumps `@mctx-ai/mcp` from `^2.0.0` to `^2.0.2`, pulling in the upstream patches from `mctx-ai/app` PR #70 and #71 that strip the `createRequire` path and eliminate the `import.meta.url` references. No source code, tests, or build config change — the bundle keeps `--external:@mctx-ai/mcp` and the mctx platform resolves the Workers-compatible framework at runtime from the declared version. On merge, `release.yml` syncs the updated `package.json` to the `release` branch and the mctx platform redeploys with the compatible framework.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)