### PR TITLE
fix(build): remove --external:@mctx-ai/mcp from production esbuild script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "bible-study",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bible-study",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "license": "MIT",
       "dependencies": {
-        "@mctx-ai/mcp": "^2.0.0"
+        "@mctx-ai/mcp": "^2.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@mctx-ai/mcp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp/-/mcp-2.0.0.tgz",
-      "integrity": "sha512-NIc8HCrBAs1hD1iVpJjx77Pudnb95PTLlS2+iVrCVYLujfwrxvJ4NQ5BSgWLU8AtuZyBulx/NBnnAnFlIt49Qw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mctx-ai/mcp/-/mcp-2.0.2.tgz",
+      "integrity": "sha512-Dyjtxe/qNb6od/KkRmWzMJhQ2MWgZKY608+fNMWHCyQ4tgJaALg9PqHowyKgK6i5N2svJW/sGzkUz0xrkDbWfQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bible-study",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "The best way to Build an MCP Server. Deep Bible study using semantic search, cross-references, topical search, and translation tools. 155,510 verses with 606,140 cross-references. What does the Bible say about suffering? Topical search surfaces Job as the Bible's principal witness on suffering (with explanations of why it matters and suggested starting passages), Psalms on lament, Romans on justification — whole books and narratives alongside individual verses. What is the Hebrew word behind lovingkindness in Psalm 23? Compare how KJV and WEB translate John 3:16. Trace the word grace through Paul's letters. Covers KJV, WEB, ASV, YLT, and Darby with 17,543 Strong's entries, BDB and Thayer lexicon definitions, and Nave's 5,319 topical categories.",
   "homepage": "https://github.com/mctx-ai/bible-study",
   "repository": {
@@ -32,7 +32,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --minify --platform=neutral --target=es2020 --format=esm --external:@mctx-ai/mcp --outfile=dist/index.js",
+    "build": "esbuild src/index.ts --bundle --minify --platform=neutral --target=es2020 --format=esm --outfile=dist/index.js",
     "db:schema": "tsx scripts/create-schema.ts",
     "dev": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/mcp --sourcemap && run-p dev:build dev:server",
     "dev:build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@mctx-ai/mcp --watch --sourcemap",
@@ -57,7 +57,7 @@
     "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.scripts.json"
   },
   "dependencies": {
-    "@mctx-ai/mcp": "^2.0.0"
+    "@mctx-ai/mcp": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
## Why

Production deploys of bible-study.mctx.ai have been silently failing since v1.11.4 (PR #41, v2 framework migration). The mctx platform falls back to v1.11.3 on failure, so the service appears healthy from the outside — but users have been served a 2-version-stale codebase without the v2 framework migration or the @mctx-ai/mcp ^2.0.2 dep bump from PR #43. Every subsequent deploy will keep failing until this is fixed.

## What This Does

Removes `--external:@mctx-ai/mcp` from the esbuild **production** build script only — dev and dev:build retain it for fast local iteration. The flag was inlining the mctx framework's name as a bare ESM `import{createServer}from"@mctx-ai/mcp"` into `dist/index.js`, which Cloudflare Workers cannot resolve because the mctx platform doesn't host-provide `@mctx-ai/mcp`. After this change, esbuild bundles the full library (89.1kb vs ~74kb broken), producing a self-contained Workers-compatible artifact. Verified: zero bare `@mctx-ai/mcp` imports, zero `createRequire`, zero `import.meta.url` in the rebuilt bundle.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)